### PR TITLE
Add Event Collaborator Management APIs

### DIFF
--- a/src/controllers/collaboratorController.ts
+++ b/src/controllers/collaboratorController.ts
@@ -1,0 +1,243 @@
+import Collaborator from "../models/Collaborator.js"
+import Event from "../models/Event.js"
+
+export const createCollaborator = async (req, res) => {
+  try {
+    const { name, email, image, event, role } = req.body
+
+    // Check if event exists
+    const eventDoc = await Event.findById(event)
+    if (!eventDoc) {
+      return res.status(404).json({ error: "Event not found" })
+    }
+
+    // Check if user has permission to add collaborators to this event
+    if (eventDoc.organizer.toString() !== req.user._id.toString() && req.user.role !== "admin") {
+      return res.status(403).json({
+        error: "You can only add collaborators to your own events",
+      })
+    }
+
+    // Check collaborator limit
+    const existingCollaborators = await Collaborator.countDocuments({
+      event,
+      status: { $ne: "declined" },
+    })
+
+    if (existingCollaborators >= 5) {
+      return res.status(400).json({
+        error: "Maximum number of collaborators (5) reached for this event",
+      })
+    }
+
+    // Check if collaborator already exists for this event
+    const existingCollaborator = await Collaborator.findOne({ email, event })
+    if (existingCollaborator) {
+      return res.status(400).json({
+        error: "This email is already associated with this event",
+      })
+    }
+
+    const collaborator = new Collaborator({
+      name,
+      email,
+      image,
+      event,
+      role: role || "volunteer",
+      invitedBy: req.user._id,
+    })
+
+    await collaborator.save()
+
+    // Add collaborator to event
+    await Event.findByIdAndUpdate(event, {
+      $push: { collaborators: collaborator._id },
+    })
+
+    const populatedCollaborator = await Collaborator.findById(collaborator._id)
+      .populate("event", "title date location")
+      .populate("invitedBy", "name email")
+
+    res.status(201).json({
+      message: "Collaborator added successfully",
+      collaborator: populatedCollaborator,
+    })
+  } catch (error) {
+    res.status(500).json({ error: error.message })
+  }
+}
+
+export const getAllCollaborators = async (req, res) => {
+  try {
+    const page = Number.parseInt(req.query.page) || 1
+    const limit = Number.parseInt(req.query.limit) || 10
+    const skip = (page - 1) * limit
+
+    // Build query based on user role
+    const query = {}
+    if (req.user.role !== "admin") {
+      // Non-admin users can only see collaborators from their events
+      const userEvents = await Event.find({ organizer: req.user._id }).select("_id")
+      const eventIds = userEvents.map((event) => event._id)
+      query.event = { $in: eventIds }
+    }
+
+    const collaborators = await Collaborator.find(query)
+      .populate("event", "title date location")
+      .populate("invitedBy", "name email")
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+
+    const total = await Collaborator.countDocuments(query)
+
+    res.json({
+      collaborators,
+      pagination: {
+        current: page,
+        pages: Math.ceil(total / limit),
+        total,
+      },
+    })
+  } catch (error) {
+    res.status(500).json({ error: error.message })
+  }
+}
+
+export const getCollaboratorById = async (req, res) => {
+  try {
+    const { id } = req.params
+
+    const collaborator = await Collaborator.findById(id)
+      .populate("event", "title date location organizer")
+      .populate("invitedBy", "name email")
+
+    if (!collaborator) {
+      return res.status(404).json({ error: "Collaborator not found" })
+    }
+
+    // Check if user has permission to view this collaborator
+    if (req.user.role !== "admin" && collaborator.event.organizer.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        error: "Access denied. You can only view collaborators from your own events.",
+      })
+    }
+
+    res.json({ collaborator })
+  } catch (error) {
+    res.status(500).json({ error: error.message })
+  }
+}
+
+export const getCollaboratorsByEvent = async (req, res) => {
+  try {
+    const { eventId } = req.params
+
+    const event = await Event.findById(eventId)
+    if (!event) {
+      return res.status(404).json({ error: "Event not found" })
+    }
+
+    // Check if user has permission to view collaborators for this event
+    if (req.user.role !== "admin" && event.organizer.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        error: "Access denied. You can only view collaborators from your own events.",
+      })
+    }
+
+    const collaborators = await Collaborator.find({ event: eventId })
+      .populate("invitedBy", "name email")
+      .sort({ createdAt: -1 })
+
+    res.json({
+      collaborators,
+      event: {
+        id: event._id,
+        title: event.title,
+        date: event.date,
+        location: event.location,
+      },
+    })
+  } catch (error) {
+    res.status(500).json({ error: error.message })
+  }
+}
+
+export const updateCollaborator = async (req, res) => {
+  try {
+    const { id } = req.params
+    const updates = req.body
+
+    const collaborator = await Collaborator.findById(id).populate("event")
+    if (!collaborator) {
+      return res.status(404).json({ error: "Collaborator not found" })
+    }
+
+    // Check if user has permission to update this collaborator
+    if (req.user.role !== "admin" && collaborator.event.organizer.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        error: "Access denied. You can only update collaborators from your own events.",
+      })
+    }
+
+    // If email is being updated, check for duplicates
+    if (updates.email && updates.email !== collaborator.email) {
+      const existingCollaborator = await Collaborator.findOne({
+        email: updates.email,
+        event: collaborator.event._id,
+        _id: { $ne: id },
+      })
+
+      if (existingCollaborator) {
+        return res.status(400).json({
+          error: "This email is already associated with this event",
+        })
+      }
+    }
+
+    // Update responded date if status is being changed
+    if (updates.status && updates.status !== collaborator.status) {
+      updates.respondedAt = new Date()
+    }
+
+    const updatedCollaborator = await Collaborator.findByIdAndUpdate(id, updates, { new: true, runValidators: true })
+      .populate("event", "title date location")
+      .populate("invitedBy", "name email")
+
+    res.json({
+      message: "Collaborator updated successfully",
+      collaborator: updatedCollaborator,
+    })
+  } catch (error) {
+    res.status(500).json({ error: error.message })
+  }
+}
+
+export const deleteCollaborator = async (req, res) => {
+  try {
+    const { id } = req.params
+
+    const collaborator = await Collaborator.findById(id).populate("event")
+    if (!collaborator) {
+      return res.status(404).json({ error: "Collaborator not found" })
+    }
+
+    // Check if user has permission to delete this collaborator
+    if (req.user.role !== "admin" && collaborator.event.organizer.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        error: "Access denied. You can only delete collaborators from your own events.",
+      })
+    }
+
+    // Remove collaborator from event
+    await Event.findByIdAndUpdate(collaborator.event._id, {
+      $pull: { collaborators: id },
+    })
+
+    await Collaborator.findByIdAndDelete(id)
+
+    res.json({ message: "Collaborator removed successfully" })
+  } catch (error) {
+    res.status(500).json({ error: error.message })
+  }
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,59 @@
+import jwt from "jsonwebtoken"
+import User from "../models/User.js"
+
+export const authenticate = async (req, res, next) => {
+  try {
+    const token = req.header("Authorization")?.replace("Bearer ", "")
+
+    if (!token) {
+      return res.status(401).json({ error: "Access denied. No token provided." })
+    }
+
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret")
+    const user = await User.findById(decoded.id).select("-password")
+
+    if (!user || !user.isActive) {
+      return res.status(401).json({ error: "Invalid token or user not found." })
+    }
+
+    req.user = user
+    next()
+  } catch (error) {
+    res.status(401).json({ error: "Invalid token." })
+  }
+}
+
+export const authorize = (...roles) => {
+  return (req, res, next) => {
+    if (!roles.includes(req.user.role)) {
+      return res.status(403).json({
+        error: "Access denied. Insufficient permissions.",
+      })
+    }
+    next()
+  }
+}
+
+export const checkEventOwnership = async (req, res, next) => {
+  try {
+    const { eventId } = req.params
+    const Event = (await import("../models/Event.js")).default
+
+    const event = await Event.findById(eventId)
+    if (!event) {
+      return res.status(404).json({ error: "Event not found" })
+    }
+
+    // Allow access if user is the organizer or an admin
+    if (event.organizer.toString() !== req.user._id.toString() && req.user.role !== "admin") {
+      return res.status(403).json({
+        error: "Access denied. You can only manage collaborators for your own events.",
+      })
+    }
+
+    req.event = event
+    next()
+  } catch (error) {
+    res.status(500).json({ error: "Server error during authorization check" })
+  }
+}

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,0 +1,45 @@
+export const errorHandler = (err, req, res, next) => {
+  console.error(err.stack)
+
+  // Mongoose validation error
+  if (err.name === "ValidationError") {
+    const errors = Object.values(err.errors).map((e) => e.message)
+    return res.status(400).json({
+      error: "Validation Error",
+      details: errors,
+    })
+  }
+
+  // Mongoose duplicate key error
+  if (err.code === 11000) {
+    const field = Object.keys(err.keyValue)[0]
+    return res.status(400).json({
+      error: `Duplicate ${field}. This ${field} already exists.`,
+    })
+  }
+
+  // Mongoose cast error
+  if (err.name === "CastError") {
+    return res.status(400).json({
+      error: "Invalid ID format",
+    })
+  }
+
+  // JWT errors
+  if (err.name === "JsonWebTokenError") {
+    return res.status(401).json({
+      error: "Invalid token",
+    })
+  }
+
+  if (err.name === "TokenExpiredError") {
+    return res.status(401).json({
+      error: "Token expired",
+    })
+  }
+
+  // Default error
+  res.status(err.status || 500).json({
+    error: err.message || "Internal Server Error",
+  })
+}

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,0 +1,60 @@
+import { body, param, validationResult } from "express-validator"
+
+export const validateCollaborator = [
+  body("name").trim().isLength({ min: 2, max: 100 }).withMessage("Name must be between 2 and 100 characters"),
+
+  body("email").isEmail().normalizeEmail().withMessage("Please provide a valid email address"),
+
+  body("image")
+    .isURL()
+    .matches(/\.(jpg|jpeg|png|gif|webp)$/i)
+    .withMessage("Please provide a valid image URL (jpg, jpeg, png, gif, webp)"),
+
+  body("event").isMongoId().withMessage("Please provide a valid event ID"),
+
+  body("role")
+    .optional()
+    .isIn(["coordinator", "assistant", "specialist", "volunteer"])
+    .withMessage("Role must be one of: coordinator, assistant, specialist, volunteer"),
+]
+
+export const validateCollaboratorUpdate = [
+  body("name")
+    .optional()
+    .trim()
+    .isLength({ min: 2, max: 100 })
+    .withMessage("Name must be between 2 and 100 characters"),
+
+  body("email").optional().isEmail().normalizeEmail().withMessage("Please provide a valid email address"),
+
+  body("image")
+    .optional()
+    .isURL()
+    .matches(/\.(jpg|jpeg|png|gif|webp)$/i)
+    .withMessage("Please provide a valid image URL"),
+
+  body("role")
+    .optional()
+    .isIn(["coordinator", "assistant", "specialist", "volunteer"])
+    .withMessage("Role must be one of: coordinator, assistant, specialist, volunteer"),
+
+  body("status")
+    .optional()
+    .isIn(["pending", "accepted", "declined"])
+    .withMessage("Status must be one of: pending, accepted, declined"),
+]
+
+export const validateMongoId = [param("id").isMongoId().withMessage("Please provide a valid ID")]
+
+export const validateEventId = [param("eventId").isMongoId().withMessage("Please provide a valid event ID")]
+
+export const handleValidationErrors = (req, res, next) => {
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      error: "Validation failed",
+      details: errors.array(),
+    })
+  }
+  next()
+}

--- a/src/model/Collaborator.ts
+++ b/src/model/Collaborator.ts
@@ -1,0 +1,65 @@
+import mongoose from "mongoose"
+
+const collaboratorSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 100,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+      match: [/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/, "Please enter a valid email"],
+    },
+    image: {
+      type: String,
+      required: true,
+      validate: {
+        validator: (v) => /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i.test(v),
+        message: "Please provide a valid image URL",
+      },
+    },
+    event: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Event",
+      required: true,
+    },
+    role: {
+      type: String,
+      enum: ["coordinator", "assistant", "specialist", "volunteer"],
+      default: "volunteer",
+    },
+    status: {
+      type: String,
+      enum: ["pending", "accepted", "declined"],
+      default: "pending",
+    },
+    invitedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    invitedAt: {
+      type: Date,
+      default: Date.now,
+    },
+    respondedAt: {
+      type: Date,
+    },
+  },
+  {
+    timestamps: true,
+  },
+)
+
+// Compound index to ensure unique email per event
+collaboratorSchema.index({ email: 1, event: 1 }, { unique: true })
+
+// Index for better query performance
+collaboratorSchema.index({ event: 1, status: 1 })
+
+export default mongoose.model("Collaborator", collaboratorSchema)

--- a/src/routes/collaborators.ts
+++ b/src/routes/collaborators.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+import {
+  createCollaborator,
+  getAllCollaborators,
+  getCollaboratorById,
+  updateCollaborator,
+  deleteCollaborator,
+} from '../controllers/collaboratorController.js';
+import { authenticate, authorize } from '../middleware/auth.js';
+import {
+  validateCollaborator,
+  validateMongoId,
+  handleValidationErrors,
+} from '../middleware/validation';
+
+const router = express.Router();
+
+router.use(authenticate);
+
+router.post(
+  '/',
+  authorize('organizer', 'admin'),
+  validateCollaborator,
+  handleValidationErrors,
+  createCollaborator
+);
+
+router.get('/', getAllCollaborators);
+
+router.get(
+  '/:id',
+  validateMongoId,
+  handleValidationErrors,
+  getCollaboratorById
+);
+
+router.put(
+  '/:id',
+  authorize('organizer', 'admin'),
+  validateMongoId,
+  handleValidationErrors,
+  updateCollaborator
+);
+
+router.delete(
+  '/:id',
+  authorize('organizer', 'admin'),
+  validateMongoId,
+  handleValidationErrors,
+  deleteCollaborator
+);
+
+export default router;


### PR DESCRIPTION
## Add Event Collaborator Management APIs

### Description

Implemented a full-featured API for managing event collaborators. Each event can have up to five collaborators with support for creation, retrieval, update, and deletion operations.

### Core Features

- Add a collaborator to an event
- Retrieve a single collaborator by ID
- Retrieve all collaborators globally or for a specific event
- Update collaborator details
- Delete a collaborator

### Endpoints

- `POST /collaborators` – Add a new collaborator
- `GET /collaborators` – Get all collaborators
- `GET /collaborators/{id}` – Get a single collaborator by ID
- `GET /events/{eventId}/collaborators` – Get all collaborators for a specific event
- `PUT /collaborators/{id}` – Update a collaborator
- `DELETE /collaborators/{id}` – Delete a collaborator

### Implementation Details

- Enforced a maximum of **five collaborators per event**
- Used DTOs for request validation
- Added authentication and role-based access control (RBAC)
- Implemented guards and middleware for access restrictions
- Validated required fields:
  - `name`
  - `email`
  - `image`
  - `eventId`

closes #54 