### PR TITLE
feat: implement transaction utils and VeriTixClient.simulate()

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
+    "globals": {
+      "ts-jest": {
+        "tsconfig": "tsconfig.test.json"
+      }
+    },
     "roots": [
       "<rootDir>/tests"
     ],

--- a/src/client.ts
+++ b/src/client.ts
@@ -26,9 +26,10 @@
  * ```
  */
 
-import { SorobanRpc, Keypair } from '@stellar/stellar-sdk';
+import { SorobanRpc, Keypair, xdr } from '@stellar/stellar-sdk';
 
-import type { NetworkConfig } from './types/index';
+import type { NetworkConfig, SimulationResult } from './types/index';
+import { buildContractCall, simulateTransaction } from './utils/transaction';
 import { TokenModule } from './modules/token';
 import { EscrowModule } from './modules/escrow';
 import { DisputeModule } from './modules/dispute';
@@ -119,15 +120,10 @@ export class VeriTixClient {
    * ```
    */
   async connect(): Promise<number> {
-    // TODO: implement
-    // Suggested steps:
-    //   1. new SorobanRpc.Server(this.config.rpcUrl, { allowHttp: false })
-    //   2. server.getLatestLedger() to verify connectivity
-    //   3. Store server reference; set this.connected = true
-    //   4. Return latestLedger.sequence
-    void SorobanRpc;
-    this.connected = true; // placeholder so TypeScript doesn't warn
-    throw new Error('VeriTixClient.connect: not implemented');
+    this.server = new SorobanRpc.Server(this.config.rpcUrl, { allowHttp: false });
+    const ledger = await this.server.getLatestLedger();
+    this.connected = true;
+    return ledger.sequence;
   }
 
   /**
@@ -135,6 +131,70 @@ export class VeriTixClient {
    */
   isConnected(): boolean {
     return this.connected;
+  }
+
+  // -------------------------------------------------------------------------
+  // Simulation  (#77)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Dry-runs any contract method without submitting a transaction.
+   * Works without a `Keypair` — no XLM is spent.
+   *
+   * @param method - Contract function name to invoke.
+   * @param args   - Ordered XDR `ScVal` arguments.
+   * @returns A {@link SimulationResult} with the return value and estimated fee.
+   *
+   * @example
+   * ```ts
+   * const result = await client.simulate('get_escrow', [nativeToScVal(1n, { type: 'u64' })]);
+   * if (result.success) console.log('Return value:', result.returnValue);
+   * ```
+   */
+  async simulate(method: string, args: xdr.ScVal[]): Promise<SimulationResult> {
+    if (!this.connected) {
+      throw new Error('VeriTixClient: call connect() before simulate()');
+    }
+
+    try {
+      // Use a throwaway source account (simulation does not require a real funded account)
+      const { Account } = await import('@stellar/stellar-sdk');
+      const dummyKeypair = Keypair.random();
+      const sourceAccount = new Account(dummyKeypair.publicKey(), '0');
+
+      const tx = await buildContractCall(
+        this.server,
+        sourceAccount,
+        this.config.contractId,
+        method,
+        args,
+        this.config.networkPassphrase,
+      );
+
+      const { transaction, simulatedFee } = await simulateTransaction(this.server, tx);
+
+      // Extract the return value from the simulation result XDR if available
+      const rawResult = await this.server.simulateTransaction(tx);
+      const returnValue =
+        SorobanRpc.Api.isSimulationSuccess(rawResult) && rawResult.result
+          ? rawResult.result.retval
+          : undefined;
+
+      void transaction; // assembled tx not needed for simulate-only path
+
+      return {
+        success: true,
+        returnValue,
+        estimatedFee: simulatedFee,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        returnValue: undefined,
+        estimatedFee: '0',
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -166,3 +166,17 @@ export interface TransactionResult {
   /** Whether the transaction was successful */
   successful: boolean;
 }
+
+/**
+ * Result of a dry-run simulation via {@link VeriTixClient.simulate}.
+ */
+export interface SimulationResult {
+  /** Whether the simulated call would succeed */
+  success: boolean;
+  /** The decoded return value from the contract (if successful) */
+  returnValue: unknown;
+  /** Estimated transaction fee in stroops */
+  estimatedFee: string;
+  /** Error message if the simulation failed */
+  error?: string;
+}

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 /**
  * @module utils/transaction
  * Low-level helpers for building, simulating, signing, and submitting
@@ -8,6 +9,7 @@
  */
 
 import {
+  Contract,
   SorobanRpc,
   Transaction,
   TransactionBuilder,
@@ -18,7 +20,7 @@ import {
 } from '@stellar/stellar-sdk';
 
 import type { TransactionResult } from '../types/index';
-import { parseSorobanError } from './errors';
+import { parseSorobanError, VeriTixError, VeriTixErrorCode } from './errors';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,8 +37,13 @@ export interface PreparedTransaction {
   simulatedFee: string;
 }
 
+/** Maximum number of polling attempts before throwing a TIMEOUT error. */
+const MAX_POLL_ATTEMPTS = 20;
+/** Milliseconds between each polling attempt. */
+const POLL_INTERVAL_MS = 2_000;
+
 // ---------------------------------------------------------------------------
-// Build
+// Build  (#78)
 // ---------------------------------------------------------------------------
 
 /**
@@ -50,18 +57,6 @@ export interface PreparedTransaction {
  * @param args           - Ordered list of XDR `ScVal` arguments for the call.
  * @param networkPassphrase - Stellar network passphrase for envelope signing.
  * @returns An unsigned `Transaction` ready for simulation.
- *
- * @example
- * ```ts
- * const tx = await buildContractCall(
- *   server,
- *   account,
- *   config.contractId,
- *   'create_escrow',
- *   [nativeToScVal(beneficiary, { type: 'address' }), nativeToScVal(amount, { type: 'i128' })],
- *   config.networkPassphrase,
- * );
- * ```
  */
 export async function buildContractCall(
   server: SorobanRpc.Server,
@@ -71,26 +66,24 @@ export async function buildContractCall(
   args: xdr.ScVal[],
   networkPassphrase: string,
 ): Promise<Transaction> {
-  // TODO: implement
-  // Suggested steps:
-  //   1. new Contract(contractId).call(method, ...args) → Operation
-  //   2. new TransactionBuilder(sourceAccount, { fee: BASE_FEE, networkPassphrase })
-  //        .addOperation(op)
-  //        .setTimeout(30)
-  //        .build()
+  // server is not used at build time; the account is loaded by the caller
   void server;
-  void sourceAccount;
-  void contractId;
-  void method;
-  void args;
-  void networkPassphrase;
-  void BASE_FEE;
-  void TransactionBuilder;
-  throw new Error('buildContractCall: not implemented');
+
+  const operation = new Contract(contractId).call(method, ...args);
+
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(operation)
+    .setTimeout(30)
+    .build();
+
+  return tx as Transaction;
 }
 
 // ---------------------------------------------------------------------------
-// Simulate
+// Simulate  (#79)
 // ---------------------------------------------------------------------------
 
 /**
@@ -101,31 +94,27 @@ export async function buildContractCall(
  * @param tx     - An unsigned transaction built by {@link buildContractCall}.
  * @returns A {@link PreparedTransaction} containing the assembled tx and fee.
  * @throws {VeriTixError} If the simulation returns an error response.
- *
- * @example
- * ```ts
- * const { transaction, simulatedFee } = await simulateTransaction(server, unsignedTx);
- * console.log('Estimated fee (stroops):', simulatedFee);
- * ```
  */
 export async function simulateTransaction(
   server: SorobanRpc.Server,
   tx: Transaction,
 ): Promise<PreparedTransaction> {
-  // TODO: implement
-  // Suggested steps:
-  //   1. server.simulateTransaction(tx)
-  //   2. Check SorobanRpc.isSimulationError(result) → throw parseSorobanError
-  //   3. SorobanRpc.assembleTransaction(tx, result).build()
-  //   4. Return { transaction: assembled, simulatedFee: result.minResourceFee }
-  void server;
-  void tx;
-  void parseSorobanError;
-  throw new Error('simulateTransaction: not implemented');
+  const result = await server.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(result)) {
+    throw parseSorobanError(result.error);
+  }
+
+  const assembled = SorobanRpc.assembleTransaction(tx, result).build();
+
+  return {
+    transaction: assembled as Transaction,
+    simulatedFee: result.minResourceFee,
+  };
 }
 
 // ---------------------------------------------------------------------------
-// Submit
+// Submit  (#80)
 // ---------------------------------------------------------------------------
 
 /**
@@ -134,30 +123,69 @@ export async function simulateTransaction(
  *
  * @param server  - An initialised `SorobanRpc.Server` instance.
  * @param tx      - A transaction that has already been through
- *                  {@link simulateTransaction} (i.e. assembled & fee-bumped).
+ *                  {@link simulateTransaction} (assembled & fee-bumped).
  * @param keypair - The `Keypair` used to sign the transaction envelope.
+ * @param maxAttempts - Maximum poll attempts before throwing TIMEOUT (default 20).
  * @returns A {@link TransactionResult} with the hash and final ledger.
  * @throws {VeriTixError} If submission or polling returns an error.
- *
- * @example
- * ```ts
- * const result = await submitTransaction(server, preparedTx, myKeypair);
- * console.log('Tx hash:', result.hash);
- * ```
  */
 export async function submitTransaction(
   server: SorobanRpc.Server,
   tx: Transaction,
   keypair: Keypair,
+  maxAttempts: number = MAX_POLL_ATTEMPTS,
 ): Promise<TransactionResult> {
-  // TODO: implement
-  // Suggested steps:
-  //   1. tx.sign(keypair)
-  //   2. server.sendTransaction(tx) → check for PENDING / ERROR
-  //   3. Poll server.getTransaction(hash) until status !== NOT_FOUND
-  //   4. Return { hash, ledger, successful: status === SUCCESS }
-  void server;
-  void tx;
-  void keypair;
-  throw new Error('submitTransaction: not implemented');
+  // 1. Sign
+  tx.sign(keypair);
+
+  // 2. Submit
+  const sendResponse = await server.sendTransaction(tx);
+
+  if (sendResponse.status === 'ERROR') {
+    throw parseSorobanError(
+      sendResponse.errorResult?.toXDR('base64') ?? 'Transaction submission failed',
+    );
+  }
+
+  const hash = sendResponse.hash;
+
+  // 3. Poll until confirmed
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await sleep(POLL_INTERVAL_MS);
+
+    const response = await server.getTransaction(hash);
+
+    if (response.status === 'NOT_FOUND') {
+      continue;
+    }
+
+    if (response.status === 'FAILED') {
+      throw new VeriTixError(
+        VeriTixErrorCode.Unknown,
+        `Transaction failed on-chain: ${hash}`,
+        response.resultXdr?.toXDR('base64'),
+      );
+    }
+
+    if (response.status === 'SUCCESS') {
+      return {
+        hash,
+        ledger: response.ledger,
+        successful: true,
+      };
+    }
+  }
+
+  throw new VeriTixError(
+    VeriTixErrorCode.Unknown,
+    `Transaction ${hash} not confirmed after ${maxAttempts} polling attempts (TIMEOUT)`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -75,12 +75,21 @@ describe('VeriTixClient', () => {
   });
 
   // -------------------------------------------------------------------------
-  // connect() — stub guard
+  // connect()
   // -------------------------------------------------------------------------
 
   describe('connect()', () => {
-    it('throws "not implemented" until connect() is built out', async () => {
-      await expect(client.connect()).rejects.toThrow('not implemented');
+    it('resolves to a ledger sequence number', async () => {
+      // Mock the RPC server so no real network call is made
+      const { SorobanRpc } = await import('@stellar/stellar-sdk');
+      jest.spyOn(SorobanRpc, 'Server').mockImplementation(() => ({
+        getLatestLedger: jest.fn().mockResolvedValue({ sequence: 12345 }),
+      }) as any);
+
+      const ledger = await client.connect();
+      expect(typeof ledger).toBe('number');
+      expect(ledger).toBe(12345);
+      expect(client.isConnected()).toBe(true);
     });
   });
 });

--- a/tests/utils/transaction.test.ts
+++ b/tests/utils/transaction.test.ts
@@ -1,0 +1,247 @@
+/**
+ * @file tests/utils/transaction.test.ts
+ * Unit tests for buildContractCall, simulateTransaction, and submitTransaction.
+ * All Soroban RPC calls are mocked — no network access required.
+ */
+
+import {
+  Keypair,
+  Account,
+  SorobanRpc,
+  xdr,
+  nativeToScVal,
+} from '@stellar/stellar-sdk';
+
+import {
+  buildContractCall,
+  simulateTransaction,
+  submitTransaction,
+} from '../../src/utils/transaction';
+import { VeriTixError, VeriTixErrorCode } from '../../src/utils/errors';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const FAKE_CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+const keypair = Keypair.random();
+const sourceAccount = new Account(keypair.publicKey(), '100');
+
+function makeMockServer(overrides: Partial<SorobanRpc.Server> = {}): SorobanRpc.Server {
+  return {
+    simulateTransaction: jest.fn(),
+    sendTransaction: jest.fn(),
+    getTransaction: jest.fn(),
+    getAccount: jest.fn(),
+    getLatestLedger: jest.fn(),
+    ...overrides,
+  } as unknown as SorobanRpc.Server;
+}
+
+// ---------------------------------------------------------------------------
+// buildContractCall  (#78)
+// ---------------------------------------------------------------------------
+
+describe('buildContractCall', () => {
+  it('returns an unsigned Transaction with the correct operation', async () => {
+    const server = makeMockServer();
+    const args = [nativeToScVal(42n, { type: 'u64' })];
+
+    const tx = await buildContractCall(
+      server,
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'get_escrow',
+      args,
+      NETWORK_PASSPHRASE,
+    );
+
+    expect(tx).toBeDefined();
+    expect(tx.operations).toHaveLength(1);
+    expect(tx.operations[0].type).toBe('invokeHostFunction');
+  });
+
+  it('builds a transaction with timeout 30', async () => {
+    const server = makeMockServer();
+    const tx = await buildContractCall(
+      server,
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'ping',
+      [],
+      NETWORK_PASSPHRASE,
+    );
+
+    // TimeBounds upper bound = current time + 30
+    const timeBounds = tx.timeBounds;
+    expect(timeBounds).toBeDefined();
+    expect(Number(timeBounds!.maxTime)).toBeGreaterThan(0);
+  });
+
+  it('works with an empty args array', async () => {
+    const server = makeMockServer();
+    const tx = await buildContractCall(
+      server,
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'no_args_method',
+      [],
+      NETWORK_PASSPHRASE,
+    );
+    expect(tx.operations).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// simulateTransaction  (#79)
+// ---------------------------------------------------------------------------
+
+describe('simulateTransaction', () => {
+  it('returns assembled transaction and fee on success', async () => {
+    const unsignedTx = await buildContractCall(
+      makeMockServer(),
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'get_escrow',
+      [],
+      NETWORK_PASSPHRASE,
+    );
+
+    // Minimal success response — no real XDR needed
+    const mockSimResult = {
+      minResourceFee: '12345',
+      result: { retval: xdr.ScVal.scvVoid() },
+    } as unknown as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+
+    jest.spyOn(SorobanRpc.Api, 'isSimulationError').mockReturnValueOnce(false);
+    jest
+      .spyOn(SorobanRpc, 'assembleTransaction')
+      .mockReturnValueOnce({ build: () => unsignedTx } as any);
+
+    const server = makeMockServer({
+      simulateTransaction: jest.fn().mockResolvedValueOnce(mockSimResult),
+    });
+
+    const { transaction, simulatedFee } = await simulateTransaction(server, unsignedTx);
+
+    expect(simulatedFee).toBe('12345');
+    expect(transaction).toBeDefined();
+  });
+
+  it('throws VeriTixError when simulation returns an error', async () => {
+    const unsignedTx = await buildContractCall(
+      makeMockServer(),
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'fail_method',
+      [],
+      NETWORK_PASSPHRASE,
+    );
+
+    const mockErrResult = {
+      error: 'escrow not found',
+    } as unknown as SorobanRpc.Api.SimulateTransactionErrorResponse;
+
+    jest.spyOn(SorobanRpc.Api, 'isSimulationError').mockReturnValueOnce(true);
+
+    const server = makeMockServer({
+      simulateTransaction: jest.fn().mockResolvedValueOnce(mockErrResult),
+    });
+
+    await expect(simulateTransaction(server, unsignedTx)).rejects.toThrow(VeriTixError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitTransaction  (#80)
+// ---------------------------------------------------------------------------
+
+describe('submitTransaction', () => {
+  it('signs, submits, and returns result on SUCCESS after one poll', async () => {
+    const tx = await buildContractCall(
+      makeMockServer(),
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'create_escrow',
+      [],
+      NETWORK_PASSPHRASE,
+    );
+
+    const hash = 'abcdef1234567890';
+
+    const server = makeMockServer({
+      sendTransaction: jest.fn().mockResolvedValueOnce({
+        status: 'PENDING',
+        hash,
+      }),
+      getTransaction: jest
+        .fn()
+        .mockResolvedValueOnce({ status: 'NOT_FOUND' })
+        .mockResolvedValueOnce({ status: 'SUCCESS', ledger: 42, resultXdr: undefined }),
+    });
+
+    const result = await submitTransaction(server, tx, keypair, 5);
+
+    expect(result.hash).toBe(hash);
+    expect(result.ledger).toBe(42);
+    expect(result.successful).toBe(true);
+  });
+
+  it('throws immediately when sendTransaction returns ERROR', async () => {
+    const tx = await buildContractCall(
+      makeMockServer(),
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'fail',
+      [],
+      NETWORK_PASSPHRASE,
+    );
+
+    const server = makeMockServer({
+      sendTransaction: jest.fn().mockResolvedValueOnce({
+        status: 'ERROR',
+        hash: 'x',
+        errorResult: null,
+      }),
+    });
+
+    await expect(submitTransaction(server, tx, keypair)).rejects.toBeInstanceOf(VeriTixError);
+  });
+
+  it('throws VeriTixError after max poll attempts (TIMEOUT)', async () => {
+    const tx = await buildContractCall(
+      makeMockServer(),
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'slow',
+      [],
+      NETWORK_PASSPHRASE,
+    );
+
+    const server = makeMockServer({
+      sendTransaction: jest.fn().mockResolvedValueOnce({ status: 'PENDING', hash: 'abc' }),
+      getTransaction: jest.fn().mockResolvedValue({ status: 'NOT_FOUND' }),
+    });
+
+    await expect(submitTransaction(server, tx, keypair, 2)).rejects.toThrow(/TIMEOUT/i);
+  });
+
+  it('throws VeriTixError when transaction is FAILED on-chain', async () => {
+    const tx = await buildContractCall(
+      makeMockServer(),
+      sourceAccount,
+      FAKE_CONTRACT_ID,
+      'bad_tx',
+      [],
+      NETWORK_PASSPHRASE,
+    );
+
+    const server = makeMockServer({
+      sendTransaction: jest.fn().mockResolvedValueOnce({ status: 'PENDING', hash: 'xyz' }),
+      getTransaction: jest.fn().mockResolvedValueOnce({ status: 'FAILED', resultXdr: null }),
+    });
+
+    await expect(submitTransaction(server, tx, keypair, 3)).rejects.toBeInstanceOf(VeriTixError);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary

- **`buildContractCall`** (#78): builds an unsigned `invokeHostFunction` transaction using `Contract.call` + `TransactionBuilder` with 30s timeout
- **`simulateTransaction`** (#79): runs RPC simulation via `server.simulateTransaction`, checks for error response, assembles fee-bumped tx via `SorobanRpc.assembleTransaction`
- **`submitTransaction`** (#80): signs with keypair, submits to RPC, polls every 2s up to 20 attempts, throws typed `VeriTixError` on FAILED or TIMEOUT
- **`VeriTixClient.simulate()`** (#77): dry-runs any contract method without a keypair using a throwaway account; returns `SimulationResult` with `success`, `returnValue`, `estimatedFee`, and optional `error`
- **`SimulationResult`** type added to `src/types/index.ts`
- **`tsconfig.test.json`** added so IDE resolves Jest globals in test files
- Unit tests for all three util functions with fully mocked `SorobanRpc.Server`

Closes #77
Closes #78
Closes #79
Closes #80