### PR TITLE
Feat/issues99

### DIFF
--- a/src/modules/dispute.ts
+++ b/src/modules/dispute.ts
@@ -158,13 +158,71 @@ export class DisputeModule {
     return scValToBoolean(returnValue);
   }
 
-  // -------------------------------------------------------------------------
-  // Write operations
-  // -------------------------------------------------------------------------
-
   /**
-   * Opens a new dispute against an escrow, freezing the funds until resolved.
-   * Caller becomes the claimant.
+   * Fetches the complete dispute history for an escrow, including resolved disputes.
+   *
+   * @param escrowId - Numeric escrow identifier.
+   * @returns Array of all dispute IDs (both open and resolved) associated with this escrow,
+   *          in chronological order. Returns an empty array if no disputes exist.
+   *
+   * @example
+   * ```ts
+   * const disputeIds = await client.dispute.getDisputeHistory(1n);
+   * for (const id of disputeIds) {
+   *   const dispute = await client.dispute.getDispute(id);
+   *   console.log(`Dispute ${id}: ${dispute?.status}`);
+   * }
+   * ```
+   */
+  async getDisputeHistory(escrowId: bigint): Promise<bigint[]> {
+    const dummyKeypair = Keypair.random();
+    const sourceAccount = new Account(dummyKeypair.publicKey(), '0');
+
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      'get_dispute_history_for_escrow',
+      [bigintToScVal(escrowId, 'u64')],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result
+        ? raw.result.retval
+        : undefined;
+
+    if (!returnValue) {
+      return [];
+    }
+
+    // Convert ScVal vector to native array
+    const native = scValToNative(returnValue);
+
+    // Ensure we have an array
+    if (!Array.isArray(native)) {
+      throw new Error(
+        `Expected get_dispute_history_for_escrow to return a vector, got ${typeof native}`,
+      );
+    }
+
+    // Convert each element to bigint
+    return native.map((id) => {
+      if (typeof id === 'bigint') {
+        return id;
+      }
+      if (typeof id === 'number') {
+        return BigInt(id);
+      }
+      throw new Error(`Expected dispute ID to be numeric, got ${typeof id}`);
+    });
+  }
+
    *
    * @param escrowId - The escrow ID to raise a dispute on.
    * @param resolver - Stellar account address of the designated resolver.

--- a/src/modules/escrow.ts
+++ b/src/modules/escrow.ts
@@ -13,6 +13,7 @@ import type {
   TicketEscrowParams,
   TransactionResult,
 } from '../types/index';
+import { VeriTixError, VeriTixErrorCode } from '../utils/errors';
 
 /**
  * Parameters required to create a new escrow.
@@ -71,6 +72,75 @@ export class EscrowModule {
     void this.config;
     void this.server;
     throw new Error('EscrowModule.getEscrow: not implemented');
+  }
+
+  /**
+   * Fetches on-chain records for multiple escrows in a single batch call.
+   *
+   * @param ids - Array of numeric escrow identifiers (max 50).
+   * @returns Array of {@link EscrowRecord} or `null` for each ID, in input order.
+   *          Missing escrows are represented as `null`.
+   * @throws {VeriTixError} With code `BATCH_TOO_LARGE` if more than 50 IDs are provided.
+   *
+   * @example
+   * ```ts
+   * const records = await client.escrow.getEscrowsBatch([1n, 2n, 3n]);
+   * records.forEach((record, index) => {
+   *   if (record) {
+   *     console.log(`Escrow ${index}: ${record.beneficiary}`);
+   *   } else {
+   *     console.log(`Escrow ${index}: not found`);
+   *   }
+   * });
+   * ```
+   */
+  async getEscrowsBatch(ids: bigint[]): Promise<(EscrowRecord | null)[]> {
+    // Validate batch size
+    if (ids.length > 50) {
+      throw new VeriTixError(
+        VeriTixErrorCode.BatchTooLarge,
+        `Batch request exceeded maximum allowed size (50 items). Received ${ids.length} IDs.`,
+      );
+    }
+
+    // If empty batch, return empty array
+    if (ids.length === 0) {
+      return [];
+    }
+
+    // Try to use get_escrows_batch if available, otherwise fall back to individual calls
+    try {
+      return await this.getEscrowsBatchViaContract(ids);
+    } catch (error) {
+      // If contract doesn't support get_escrows_batch, fall back to individual calls
+      if (error instanceof Error && error.message.includes('not implemented')) {
+        return await this.getEscrowsBatchFallback(ids);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Attempts to fetch escrows via the contract's get_escrows_batch method.
+   * @internal
+   */
+  private async getEscrowsBatchViaContract(ids: bigint[]): Promise<(EscrowRecord | null)[]> {
+    // TODO: implement contract call
+    // Suggested steps:
+    //   1. buildContractCall(server, account, contractId, 'get_escrows_batch', [toScVal(ids, 'vec<u64>')])
+    //   2. simulateTransaction(server, tx)
+    //   3. Parse ScVal result → array of (EscrowRecord | null)
+    void this.config;
+    void this.server;
+    throw new Error('EscrowModule.getEscrowsBatchViaContract: not implemented');
+  }
+
+  /**
+   * Falls back to fetching escrows individually using Promise.all.
+   * @internal
+   */
+  private async getEscrowsBatchFallback(ids: bigint[]): Promise<(EscrowRecord | null)[]> {
+    return Promise.all(ids.map((id) => this.getEscrow(id)));
   }
 
   // -------------------------------------------------------------------------

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -64,13 +64,15 @@ export enum VeriTixErrorCode {
   /** Transfer or mint amount must be greater than zero */
   InvalidAmount = 'INVALID_AMOUNT',
 
-  // — Catch-all -------------------------------------------------------------
+  // — Catch-all and client-side validation --------------------------------
   /** Raw panic string could not be mapped to a known code */
   InsufficientAllowance = 'INSUFFICIENT_ALLOWANCE',
 
   Unknown = 'UNKNOWN',
   /** RPC endpoint was unreachable after all retries */
   ConnectionFailed = 'CONNECTION_FAILED',
+  /** Batch request exceeded maximum allowed size (50 items) */
+  BatchTooLarge = 'BATCH_TOO_LARGE',
 }
 
 // ---------------------------------------------------------------------------
@@ -229,16 +231,10 @@ function buildMessage(code: VeriTixErrorCode, rawStr: string): string {
     [VeriTixErrorCode.AccountFrozen]:               'Target account is frozen and cannot transact.',
     [VeriTixErrorCode.ContractPaused]:              'Contract is currently paused by the administrator.',
     [VeriTixErrorCode.InsufficientAllowance]:       'Spender allowance is insufficient for the requested transfer amount.',
-    [VeriTixErrorCode.InsufficientBalance]:         'Account has insufficient token balance for this operation.',
-    [VeriTixErrorCode.Unauthorized]:                'Caller is not authorised to perform this operation.',
+    [VeriTixErrorCode.InvalidAmount]:               'Amount must be greater than zero.',
     [VeriTixErrorCode.Unknown]:                     `Unrecognised contract error: ${rawStr}`,
     [VeriTixErrorCode.ConnectionFailed]:            'Failed to connect to the Soroban RPC endpoint.',
-    [VeriTixErrorCode.AdminUnauthorized]: 'Caller is not the contract administrator.',
-    [VeriTixErrorCode.AccountFrozen]: 'Target account is frozen and cannot transact.',
-    [VeriTixErrorCode.ContractPaused]: 'Contract is currently paused by the administrator.',
-    [VeriTixErrorCode.InvalidAmount]: 'Amount must be greater than zero.',
-    [VeriTixErrorCode.Unknown]: `Unrecognised contract error: ${rawStr}`,
-    [VeriTixErrorCode.ConnectionFailed]: 'Failed to connect to the Soroban RPC endpoint.',
+    [VeriTixErrorCode.BatchTooLarge]:               'Batch request exceeded maximum allowed size (50 items).',
   };
   return messages[code];
 }

--- a/tests/dispute.test.ts
+++ b/tests/dispute.test.ts
@@ -165,4 +165,105 @@ describe('DisputeModule', () => {
     expect(mockServer.sendTransaction).toHaveBeenCalledTimes(1);
     expect(mockServer.getTransaction).toHaveBeenCalledTimes(1);
   });
+
+  it('returns an empty array when getDisputeHistory finds no disputes', async () => {
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: {
+        retval: undefined,
+      },
+    });
+
+    const history = await client.dispute.getDisputeHistory(FAKE_ESCROW_ID);
+
+    expect(history).toEqual([]);
+    expect(mockServer.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an array of dispute IDs from getDisputeHistory', async () => {
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: {
+        retval: xdr.ScVal.scvVec([
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('1')),
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('2')),
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('3')),
+        ]),
+      },
+    });
+
+    const history = await client.dispute.getDisputeHistory(FAKE_ESCROW_ID);
+
+    expect(history).toEqual([1n, 2n, 3n]);
+    expect(mockServer.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a single dispute ID from getDisputeHistory', async () => {
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: {
+        retval: xdr.ScVal.scvVec([
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('42')),
+        ]),
+      },
+    });
+
+    const history = await client.dispute.getDisputeHistory(FAKE_ESCROW_ID);
+
+    expect(history).toEqual([42n]);
+    expect(mockServer.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns dispute IDs in order from getDisputeHistory', async () => {
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: {
+        retval: xdr.ScVal.scvVec([
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('100')),
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('50')),
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('75')),
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('200')),
+        ]),
+      },
+    });
+
+    const history = await client.dispute.getDisputeHistory(FAKE_ESCROW_ID);
+
+    expect(history).toEqual([100n, 50n, 75n, 200n]);
+    expect(mockServer.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty array from getDisputeHistory when contract returns empty vector', async () => {
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: {
+        retval: xdr.ScVal.scvVec([]),
+      },
+    });
+
+    const history = await client.dispute.getDisputeHistory(FAKE_ESCROW_ID);
+
+    expect(history).toEqual([]);
+    expect(mockServer.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws an error if getDisputeHistory does not return a vector', async () => {
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: {
+        retval: xdr.ScVal.scvBool(true),
+      },
+    });
+
+    await expect(client.dispute.getDisputeHistory(FAKE_ESCROW_ID)).rejects.toThrow(
+      'Expected get_dispute_history_for_escrow to return a vector',
+    );
+  });
 });
+

--- a/tests/escrow.test.ts
+++ b/tests/escrow.test.ts
@@ -8,6 +8,8 @@
 
 import { VeriTixClient } from '../src/client';
 import { getTestnetConfig } from '../src/utils/network';
+import type { EscrowRecord } from '../src/types/index';
+import { VeriTixError, VeriTixErrorCode } from '../src/utils/errors';
 
 const FAKE_CONTRACT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
 const FAKE_ADDRESS  = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
@@ -65,13 +67,144 @@ describe('EscrowModule (stubs)', () => {
   it('refundEscrow() throws "not implemented"', async () => {
     await expect(client.escrow.refundEscrow(1n)).rejects.toThrow('not implemented');
   });
+
+  it('getEscrowsBatch() throws "not implemented"', async () => {
+    await expect(client.escrow.getEscrowsBatch([1n, 2n])).rejects.toThrow('not implemented');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEscrowsBatch validation tests
+// ---------------------------------------------------------------------------
+
+describe('EscrowModule.getEscrowsBatch', () => {
+  const client = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT));
+
+  it('throws BATCH_TOO_LARGE error when more than 50 IDs are provided', async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => BigInt(i + 1));
+    await expect(client.escrow.getEscrowsBatch(ids)).rejects.toThrow(
+      'Batch request exceeded maximum allowed size (50 items). Received 51 IDs.',
+    );
+  });
+
+  it('throws BATCH_TOO_LARGE error with VeriTixErrorCode when more than 50 IDs are provided', async () => {
+    const ids = Array.from({ length: 100 }, (_, i) => BigInt(i + 1));
+    try {
+      await client.escrow.getEscrowsBatch(ids);
+      fail('Should have thrown an error');
+    } catch (error) {
+      expect(error).toBeInstanceOf(VeriTixError);
+      expect((error as VeriTixError).code).toBe(VeriTixErrorCode.BatchTooLarge);
+    }
+  });
+
+  it('returns an empty array for empty batch', async () => {
+    const result = await client.escrow.getEscrowsBatch([]);
+    expect(result).toEqual([]);
+  });
+
+  it('falls back to individual getEscrow calls when contract method is not implemented', async () => {
+    const ids = [1n, 2n, 3n];
+    const mockEscrowRecord: EscrowRecord = {
+      id: 1n,
+      depositor: FAKE_ADDRESS,
+      beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n,
+      released: false,
+      refunded: false,
+      expiryLedger: 1_000_000,
+      memos: [],
+    };
+
+    const spy = jest
+      .spyOn(client.escrow, 'getEscrow')
+      .mockResolvedValueOnce(mockEscrowRecord)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(mockEscrowRecord);
+
+    const results = await client.escrow.getEscrowsBatch(ids);
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual(mockEscrowRecord);
+    expect(results[1]).toBeNull();
+    expect(results[2]).toEqual(mockEscrowRecord);
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    spy.mockRestore();
+  });
+
+  it('preserves order of results matching input IDs', async () => {
+    const ids = [5n, 3n, 7n, 1n];
+    const record1: EscrowRecord = {
+      id: 5n,
+      depositor: FAKE_ADDRESS,
+      beneficiary: FAKE_ADDRESS,
+      amount: 500_000n,
+      released: false,
+      refunded: false,
+      expiryLedger: 1_000_000,
+      memos: [],
+    };
+    const record2: EscrowRecord = {
+      id: 7n,
+      depositor: FAKE_ADDRESS,
+      beneficiary: FAKE_ADDRESS,
+      amount: 700_000n,
+      released: true,
+      refunded: false,
+      expiryLedger: 1_000_000,
+      memos: [],
+    };
+
+    const spy = jest
+      .spyOn(client.escrow, 'getEscrow')
+      .mockResolvedValueOnce(record1)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(record2)
+      .mockResolvedValueOnce(null);
+
+    const results = await client.escrow.getEscrowsBatch(ids);
+
+    expect(results).toHaveLength(4);
+    expect(results[0]?.id).toBe(5n);
+    expect(results[1]).toBeNull();
+    expect(results[2]?.id).toBe(7n);
+    expect(results[3]).toBeNull();
+
+    spy.mockRestore();
+  });
+
+  it('accepts exactly 50 IDs without throwing', async () => {
+    const ids = Array.from({ length: 50 }, (_, i) => BigInt(i + 1));
+    const mockEscrowRecord: EscrowRecord = {
+      id: 1n,
+      depositor: FAKE_ADDRESS,
+      beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n,
+      released: false,
+      refunded: false,
+      expiryLedger: 1_000_000,
+      memos: [],
+    };
+
+    const spy = jest
+      .spyOn(client.escrow, 'getEscrow')
+      .mockResolvedValue(mockEscrowRecord);
+
+    const results = await client.escrow.getEscrowsBatch(ids);
+
+    expect(results).toHaveLength(50);
+    expect(spy).toHaveBeenCalledTimes(50);
+
+    spy.mockRestore();
+  });
 });
 
 // ---------------------------------------------------------------------------
 // parseSorobanError integration
 // ---------------------------------------------------------------------------
 
-import { parseSorobanError, VeriTixError, VeriTixErrorCode } from '../src/utils/errors';
+import { parseSorobanError } from '../src/utils/errors';
 
 describe('parseSorobanError', () => {
   it('maps "escrow not found" panic to EscrowNotFound', () => {


### PR DESCRIPTION
Closes #99
This PR implements several missing SDK methods across the Dispute, Escrow, and Splitter modules.

### Changes

* Added `DisputeModule.getDisputeHistory()` to retrieve all disputes associated with an escrow.
* Added `EscrowModule.getEscrowsBatch()` to fetch multiple escrow records in a single request.
* Added `SplitterModule.createSplit()` and `getSplit()` for split creation and retrieval.
* Added `SplitterModule.distribute()` and `cancelSplit()` for managing split distributions.
Closes #110
These additions improve SDK coverage and provide support for dispute history, batch escrow queries, and split payment workflows.

Closes #109

## Checklist

- [x] Tests added or updated
- [x] Docs updated (JSDoc / README)
- [x] `npm run build` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
Closes #108