### PR TITLE
feat: implement BatchModule.mintBatch() with validation and unit tests

### DIFF
--- a/src/modules/batch.ts
+++ b/src/modules/batch.ts
@@ -6,8 +6,13 @@
  * invocation to reduce transaction overhead and fees.
  */
 
-import { SorobanRpc, Keypair } from '@stellar/stellar-sdk';
+import { SorobanRpc, Keypair, Account, xdr, nativeToScVal } from '@stellar/stellar-sdk';
 import type { NetworkConfig, TransactionResult } from '../types/index';
+import { addressToScVal } from '../utils/scval';
+import { buildContractCall, simulateTransaction, submitTransaction } from '../utils/transaction';
+import { parseSorobanError, VeriTixError, VeriTixErrorCode } from '../utils/errors';
+
+const MINT_BATCH_MAX = 50;
 
 /**
  * A single mint instruction within a batch.
@@ -56,24 +61,84 @@ export class BatchModule {
    * Mints tokens to multiple recipients in a single contract invocation.
    * Caller must be the contract admin.
    *
-   * @param entries - Array of {@link BatchMintEntry} instructions.
+   * @param entries - Array of {@link BatchMintEntry} instructions (max 50).
    * @returns A {@link TransactionResult} on success.
    * @throws {VeriTixError} With code `ADMIN_UNAUTHORIZED` if caller is not admin.
+   * @throws {VeriTixError} With code `BATCH_TOO_LARGE` if more than 50 entries are provided.
+   * @throws {VeriTixError} With code `INVALID_AMOUNT` if any amount is <= 0n.
+   * @throws {Error} If duplicate recipient addresses are detected.
    *
    * @example
    * ```ts
    * await client.batch.mintBatch([
-   *   { to: 'GABC…', amount: 1_000_000n },
-   *   { to: 'GXYZ…', amount: 2_000_000n },
+   *   { to: 'GABC...', amount: 1_000_000n },
+   *   { to: 'GXYZ...', amount: 2_000_000n },
    * ]);
    * ```
    */
-  async mintBatch(_entries: BatchMintEntry[]): Promise<TransactionResult> {
-    // TODO: implement
-    void this.config;
-    void this.server;
-    void this.keypair;
-    throw new Error('BatchModule.mintBatch: not implemented');
+  async mintBatch(entries: BatchMintEntry[]): Promise<TransactionResult> {
+    if (!this.keypair) {
+      throw new VeriTixError(
+        VeriTixErrorCode.AdminUnauthorized,
+        'BatchModule.mintBatch: admin Keypair required',
+      );
+    }
+
+    if (entries.length === 0) {
+      throw new Error('BatchModule.mintBatch: entries array must not be empty');
+    }
+
+    if (entries.length > MINT_BATCH_MAX) {
+      throw new VeriTixError(
+        VeriTixErrorCode.BatchTooLarge,
+        `BatchModule.mintBatch: max ${MINT_BATCH_MAX} recipients per batch, got ${entries.length}`,
+      );
+    }
+
+    for (const entry of entries) {
+      if (entry.amount <= 0n) {
+        throw new VeriTixError(
+          VeriTixErrorCode.InvalidAmount,
+          `BatchModule.mintBatch: all amounts must be > 0, got ${entry.amount} for ${entry.to}`,
+        );
+      }
+    }
+
+    const seen = new Set<string>();
+    for (const entry of entries) {
+      if (seen.has(entry.to)) {
+        throw new Error(
+          `BatchModule.mintBatch: duplicate recipient address detected: ${entry.to}`,
+        );
+      }
+      seen.add(entry.to);
+    }
+
+    const admin = this.keypair.publicKey();
+    const sourceAccount = new Account(admin, '0');
+
+    const recipients = xdr.ScVal.scvVec(
+      entries.map((e) =>
+        xdr.ScVal.scvVec([
+          addressToScVal(e.to),
+          nativeToScVal(e.amount, { type: 'i128' }),
+        ]),
+      ),
+    );
+
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      'mint_batch',
+      [addressToScVal(admin), recipients],
+      this.config.networkPassphrase,
+    );
+
+    const { transaction } = await simulateTransaction(this.server, tx);
+    const result = await submitTransaction(this.server, transaction, this.keypair);
+
+    return result;
   }
 
   /**
@@ -87,8 +152,8 @@ export class BatchModule {
    * @example
    * ```ts
    * await client.batch.transferBatch([
-   *   { from: 'GABC…', to: 'G111…', amount: 500_000n },
-   *   { from: 'GABC…', to: 'G222…', amount: 500_000n },
+   *   { from: 'GABC...', to: 'G111...', amount: 500_000n },
+   *   { from: 'GABC...', to: 'G222...', amount: 500_000n },
    * ]);
    * ```
    */

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -1,0 +1,140 @@
+﻿/**
+ * @file tests/batch.test.ts
+ * Unit tests for BatchModule.mintBatch().
+ */
+
+import { Keypair, SorobanRpc } from "@stellar/stellar-sdk";
+import { VeriTixClient } from "../src/client";
+import { getTestnetConfig } from "../src/utils/network";
+import { VeriTixError, VeriTixErrorCode } from "../src/utils/errors";
+import type { BatchMintEntry } from "../src/modules/batch";
+
+const FAKE_CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+
+jest.mock("../src/utils/transaction", () => {
+  const actual = jest.requireActual("../src/utils/transaction");
+  return {
+    ...actual,
+    buildContractCall: jest.fn().mockResolvedValue({}),
+    simulateTransaction: jest.fn().mockResolvedValue({ transaction: {}, simulatedFee: "100" }),
+    submitTransaction: jest.fn().mockResolvedValue({ hash: "mockhash", ledger: 1, successful: true }),
+  };
+});
+
+import * as txUtils from "../src/utils/transaction";
+
+function makeConnectedClient(keypair?: Keypair) {
+  const client = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT), keypair);
+  const mockServer = {
+    simulateTransaction: jest.fn(),
+    sendTransaction: jest.fn(),
+    getTransaction: jest.fn(),
+    getLatestLedger: jest.fn().mockResolvedValue({ sequence: 100 }),
+  };
+  (client as any).server = mockServer;
+  (client as any).connected = true;
+  return { client, mockServer };
+}
+
+function addr() { return Keypair.random().publicKey(); }
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("BatchModule.mintBatch — validation", () => {
+  it("throws ADMIN_UNAUTHORIZED when no keypair provided", async () => {
+    const { client } = makeConnectedClient();
+    await expect(client.batch.mintBatch([{ to: addr(), amount: 1n }]))
+      .rejects.toMatchObject({ code: VeriTixErrorCode.AdminUnauthorized });
+  });
+
+  it("throws for empty entries array", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    await expect(client.batch.mintBatch([]))
+      .rejects.toThrow("must not be empty");
+  });
+
+  it("throws BATCH_TOO_LARGE when more than 50 entries provided", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    const entries: BatchMintEntry[] = Array.from({ length: 51 }, () => ({ to: addr(), amount: 1n }));
+    await expect(client.batch.mintBatch(entries))
+      .rejects.toMatchObject({ code: VeriTixErrorCode.BatchTooLarge });
+  });
+
+  it("throws INVALID_AMOUNT for zero amount entry", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    await expect(client.batch.mintBatch([{ to: addr(), amount: 0n }]))
+      .rejects.toMatchObject({ code: VeriTixErrorCode.InvalidAmount });
+  });
+
+  it("throws INVALID_AMOUNT for negative amount entry", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    await expect(client.batch.mintBatch([{ to: addr(), amount: -1n }]))
+      .rejects.toMatchObject({ code: VeriTixErrorCode.InvalidAmount });
+  });
+
+  it("throws for duplicate recipient addresses", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    const dup = addr();
+    await expect(client.batch.mintBatch([
+      { to: dup, amount: 1n },
+      { to: dup, amount: 2n },
+    ])).rejects.toThrow("duplicate");
+  });
+
+  it("accepts exactly 50 unique recipients without throwing a validation error", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    const entries: BatchMintEntry[] = Array.from({ length: 50 }, () => ({ to: addr(), amount: 1_000n }));
+    const result = await client.batch.mintBatch(entries);
+    expect(result.successful).toBe(true);
+  });
+});
+
+describe("BatchModule.mintBatch — successful call", () => {
+  it("calls mint_batch and returns TransactionResult on success", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    const result = await client.batch.mintBatch([
+      { to: addr(), amount: 500_000n },
+      { to: addr(), amount: 750_000n },
+    ]);
+    expect(result.hash).toBe("mockhash");
+    expect(result.successful).toBe(true);
+  });
+
+  it("invokes buildContractCall with mint_batch method name", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    await client.batch.mintBatch([{ to: addr(), amount: 1_000n }]);
+    const buildMock = txUtils.buildContractCall as jest.Mock;
+    expect(buildMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      FAKE_CONTRACT,
+      "mint_batch",
+      expect.any(Array),
+      expect.any(String),
+    );
+  });
+
+  it("invokes simulateTransaction once per mintBatch call", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    await client.batch.mintBatch([{ to: addr(), amount: 1_000n }]);
+    expect(txUtils.simulateTransaction as jest.Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes submitTransaction once per mintBatch call", async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    await client.batch.mintBatch([{ to: addr(), amount: 1_000n }]);
+    expect(txUtils.submitTransaction as jest.Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the admin keypair to submitTransaction", async () => {
+    const keypair = Keypair.random();
+    const { client } = makeConnectedClient(keypair);
+    await client.batch.mintBatch([{ to: addr(), amount: 1_000n }]);
+    const submitMock = txUtils.submitTransaction as jest.Mock;
+    expect(submitMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      keypair,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `mintBatch(entries: BatchMintEntry[])` in `src/modules/batch.ts`
- Validates max 50 recipients, all amounts `> 0n`, and no duplicate recipient addresses
- Builds the `mint_batch` contract call with entries encoded as a Vec of `[address, i128 amount]` tuples
- Uses the `simulateTransaction` utility wrapper (avoids direct `SorobanRpc.assembleTransaction` calls)
- Adds 12 unit tests covering all validation branches and the successful call path

## Test plan
- [ ] `npm test` passes (all 12 new batch tests green)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

Closes #127