### PR TITLE
feat: implement AdminModule and RecurringModule methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export type {
   SplitRecipient,
   DisputeRecord,
   RecurringRecord,
+  RecurringExecutionEntry,
   TransactionResult,
 } from './types/index';
 

--- a/src/modules/admin.ts
+++ b/src/modules/admin.ts
@@ -7,8 +7,11 @@
  * {@link VeriTixErrorCode.AdminUnauthorized}.
  */
 
-import { SorobanRpc, Keypair } from '@stellar/stellar-sdk';
+import { SorobanRpc, Keypair, Account, xdr } from '@stellar/stellar-sdk';
 import type { NetworkConfig, TransactionResult } from '../types/index';
+import { addressToScVal, bigintToScVal, scValToString, scValToBoolean } from '../utils/scval';
+import { buildContractCall, simulateTransaction, submitTransaction } from '../utils/transaction';
+import { parseSorobanError, VeriTixError, VeriTixErrorCode } from '../utils/errors';
 
 /**
  * Handles all admin-level interactions with the VeriTix contract.
@@ -28,6 +31,54 @@ export class AdminModule {
   }
 
   // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private async simulateRead(method: string, args: xdr.ScVal[]): Promise<unknown> {
+    const sourceAccount = new Account(Keypair.random().publicKey(), '0');
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      method,
+      args,
+      this.config.networkPassphrase,
+    );
+
+    const simResult = await this.server.simulateTransaction(tx);
+
+    if (SorobanRpc.Api.isSimulationError(simResult)) {
+      throw parseSorobanError(simResult.error);
+    }
+
+    const retval = (simResult as SorobanRpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return retval !== undefined ? scValToBoolean(retval) : undefined;
+  }
+
+  private async writeCall(method: string, args: xdr.ScVal[]): Promise<TransactionResult> {
+    if (!this.keypair) {
+      throw new VeriTixError(
+        VeriTixErrorCode.ReadOnlyClient,
+        'A Keypair is required for write operations. Pass it to VeriTixClient.',
+      );
+    }
+
+    const sourceAccount = await this.server.getAccount(this.keypair.publicKey());
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      method,
+      args,
+      this.config.networkPassphrase,
+    );
+
+    const { transaction } = await simulateTransaction(this.server, tx);
+    return submitTransaction(this.server, transaction, this.keypair);
+  }
+
+  // -------------------------------------------------------------------------
   // Admin management
   // -------------------------------------------------------------------------
 
@@ -44,12 +95,45 @@ export class AdminModule {
    * await client.admin.setAdmin('GNEW…');
    * ```
    */
-  async setAdmin(_newAdmin: string): Promise<TransactionResult> {
-    // TODO: implement
-    void this.config;
-    void this.server;
-    void this.keypair;
-    throw new Error('AdminModule.setAdmin: not implemented');
+  async setAdmin(newAdmin: string): Promise<TransactionResult> {
+    return this.writeCall('set_admin', [addressToScVal(newAdmin)]);
+  }
+
+  /**
+   * Returns the current contract admin address.
+   *
+   * @returns The Stellar account address of the contract admin.
+   *
+   * @example
+   * ```ts
+   * const admin = await client.admin.getAdmin();
+   * console.log('Admin:', admin);
+   * ```
+   */
+  async getAdmin(): Promise<string> {
+    const dummyKeypair = Keypair.random();
+    const sourceAccount = new Account(dummyKeypair.publicKey(), '0');
+
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      'get_admin',
+      [],
+      this.config.networkPassphrase,
+    );
+
+    const simResult = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(simResult)) {
+      throw parseSorobanError(simResult.error);
+    }
+
+    const retval = (simResult as SorobanRpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+    if (!retval) {
+      throw new Error('AdminModule.getAdmin: no return value from contract');
+    }
+
+    return scValToString(retval);
   }
 
   // -------------------------------------------------------------------------
@@ -64,9 +148,8 @@ export class AdminModule {
    * @returns A {@link TransactionResult} on success.
    * @throws {VeriTixError} With code `ADMIN_UNAUTHORIZED` if caller is not admin.
    */
-  async freeze(_address: string): Promise<TransactionResult> {
-    // TODO: implement
-    throw new Error('AdminModule.freeze: not implemented');
+  async freeze(address: string): Promise<TransactionResult> {
+    return this.writeCall('freeze', [addressToScVal(address)]);
   }
 
   /**
@@ -76,9 +159,68 @@ export class AdminModule {
    * @returns A {@link TransactionResult} on success.
    * @throws {VeriTixError} With code `ADMIN_UNAUTHORIZED` if caller is not admin.
    */
-  async unfreeze(_address: string): Promise<TransactionResult> {
-    // TODO: implement
-    throw new Error('AdminModule.unfreeze: not implemented');
+  async unfreeze(address: string): Promise<TransactionResult> {
+    return this.writeCall('unfreeze', [addressToScVal(address)]);
+  }
+
+  /**
+   * Checks whether multiple accounts are frozen.
+   *
+   * @param addresses - Array of Stellar account addresses (max 100).
+   * @returns Array of booleans indicating frozen status, in input order.
+   * @throws {VeriTixError} With code `BATCH_TOO_LARGE` if more than 100 addresses are supplied.
+   *
+   * @example
+   * ```ts
+   * const statuses = await client.admin.isFrozenBatch(['GABC…', 'GXYZ…']);
+   * console.log('Frozen:', statuses);
+   * ```
+   */
+  async isFrozenBatch(addresses: string[]): Promise<boolean[]> {
+    if (addresses.length > 100) {
+      throw new VeriTixError(
+        VeriTixErrorCode.BatchTooLarge,
+        `isFrozenBatch: max 100 addresses allowed, got ${addresses.length}`,
+      );
+    }
+    return Promise.all(addresses.map((addr) => this.isFrozen(addr)));
+  }
+
+  /**
+   * Checks whether a specific account is frozen.
+   *
+   * @param address - Stellar account address to check.
+   * @returns `true` if the account is frozen, `false` otherwise.
+   */
+  async isFrozen(address: string): Promise<boolean> {
+    const result = await this.simulateRead('is_frozen', [
+      addressToScVal(address),
+    ]);
+    return result === true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Mint
+  // -------------------------------------------------------------------------
+
+  /**
+   * Mints new tokens to a recipient. Caller must be the contract admin.
+   *
+   * @param to     - Recipient Stellar account address.
+   * @param amount - Amount to mint (in stroops).
+   * @returns A {@link TransactionResult} on success.
+   * @throws {VeriTixError} With code `ADMIN_UNAUTHORIZED` if caller is not admin.
+   *
+   * @example
+   * ```ts
+   * await client.admin.mint('GABC…', 1_000_000n);
+   * ```
+   */
+  async mint(to: string, amount: bigint): Promise<TransactionResult> {
+    return this.writeCall('mint', [
+      addressToScVal(to),
+      bigintToScVal(amount, 'i128'),
+    ]);
   }
 
   // -------------------------------------------------------------------------
@@ -94,9 +236,17 @@ export class AdminModule {
    * @returns A {@link TransactionResult} on success.
    * @throws {VeriTixError} With code `ADMIN_UNAUTHORIZED` if caller is not admin.
    */
-  async clawback(_from: string, _amount: bigint): Promise<TransactionResult> {
-    // TODO: implement
-    throw new Error('AdminModule.clawback: not implemented');
+  async clawback(from: string, amount: bigint): Promise<TransactionResult> {
+    if (amount <= 0n) {
+      throw new VeriTixError(
+        VeriTixErrorCode.InvalidAmount,
+        'clawback: amount must be greater than 0',
+      );
+    }
+    return this.writeCall('clawback', [
+      addressToScVal(from),
+      bigintToScVal(amount, 'i128'),
+    ]);
   }
 
   // -------------------------------------------------------------------------
@@ -111,8 +261,7 @@ export class AdminModule {
    * @throws {VeriTixError} With code `ADMIN_UNAUTHORIZED` if caller is not admin.
    */
   async pause(): Promise<TransactionResult> {
-    // TODO: implement
-    throw new Error('AdminModule.pause: not implemented');
+    return this.writeCall('pause', []);
   }
 
   /**
@@ -122,7 +271,25 @@ export class AdminModule {
    * @throws {VeriTixError} With code `ADMIN_UNAUTHORIZED` if caller is not admin.
    */
   async unpause(): Promise<TransactionResult> {
-    // TODO: implement
-    throw new Error('AdminModule.unpause: not implemented');
+    return this.writeCall('unpause', []);
+  }
+
+  /**
+   * Checks whether the contract is currently paused.
+   *
+   * @returns `true` if the contract is paused, `false` otherwise.
+   */
+  async isPaused(): Promise<boolean> {
+    const result = await this.simulateRead('is_paused', []);
+    return result === true;
+  }
+
+  /**
+   * Alias for {@link isPaused}. Checks whether the contract is paused.
+   *
+   * @returns `true` if the contract is paused, `false` otherwise.
+   */
+  async isContractPaused(): Promise<boolean> {
+    return this.isPaused();
   }
 }

--- a/src/modules/recurring.ts
+++ b/src/modules/recurring.ts
@@ -6,8 +6,12 @@
  * at a fixed interval measured in Stellar ledger count.
  */
 
-import { SorobanRpc, Keypair } from '@stellar/stellar-sdk';
-import type { NetworkConfig, RecurringRecord, TransactionResult } from '../types/index';
+import { SorobanRpc, Keypair, Account, xdr } from '@stellar/stellar-sdk';
+import type { NetworkConfig, RecurringRecord, RecurringExecutionEntry, TransactionResult } from '../types/index';
+import { bigintToScVal } from '../utils/scval';
+import { buildContractCall } from '../utils/transaction';
+import { parseSorobanError } from '../utils/errors';
+import { parseRecurringExecutionEntry } from '../utils/parsers';
 
 /**
  * Parameters required to set up a new recurring payment.
@@ -109,6 +113,56 @@ export class RecurringModule {
   async cancel(_id: bigint): Promise<TransactionResult> {
     // TODO: implement
     throw new Error('RecurringModule.cancel: not implemented');
+  }
+
+  // -------------------------------------------------------------------------
+  // History
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetches the execution history for a recurring payment.
+   *
+   * @param id - Numeric recurring-payment identifier.
+   * @returns Array of {@link RecurringExecutionEntry} records, ordered by most recent first.
+   *
+   * @example
+   * ```ts
+   * const history = await client.recurring.getRecurringHistory(1n);
+   * for (const entry of history) {
+   *   console.log(`Ledger ${entry.executedAtLedger}: ${entry.amount} stroops`);
+   * }
+   * ```
+   */
+  async getRecurringHistory(id: bigint): Promise<RecurringExecutionEntry[]> {
+    const dummyKeypair = Keypair.random();
+    const sourceAccount = new Account(dummyKeypair.publicKey(), '0');
+
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      'get_recurring_history',
+      [bigintToScVal(id, 'u64')],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result ? raw.result.retval : undefined;
+
+    if (!returnValue || returnValue.switch() === xdr.ScValType.scvVoid()) {
+      return [];
+    }
+
+    if (returnValue.switch() !== xdr.ScValType.scvVec()) {
+      throw new Error('RecurringModule.getRecurringHistory: expected ScvVec result');
+    }
+
+    return (returnValue.vec() ?? []).map((item) => parseRecurringExecutionEntry(item));
   }
 
   // -------------------------------------------------------------------------

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -176,6 +176,21 @@ export interface DisputeRecord {
   openedAt: number;
 }
 
+/**
+ * On-chain record for a single recurring payment execution.
+ * Mirrors the `RecurringExecutionEntry` struct in the VeriTix contract.
+ */
+export interface RecurringExecutionEntry {
+  /** Numeric recurring-payment identifier */
+  recurringId: bigint;
+  /** Ledger sequence when this execution was triggered */
+  executedAtLedger: number;
+  /** Amount that was transferred (in stroops) */
+  amount: bigint;
+  /** Whether the execution was successful */
+  success: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Recurring payment
 // ---------------------------------------------------------------------------

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -13,6 +13,7 @@ import type {
   SplitRecipient,
   DisputeRecord,
   RecurringRecord,
+  RecurringExecutionEntry,
 } from '../types/index';
 import { DisputeStatus } from '../types/index';
 import {
@@ -178,6 +179,25 @@ export function parseRecurringRecord(val: xdr.ScVal): RecurringRecord {
     interval:           scValToNumber(getField(map, 'interval')),
     active:             scValToBoolean(getField(map, 'active')),
     lastChargedLedger:  scValToNumber(getField(map, 'last_charged_ledger')),
+  };
+}
+
+/**
+ * Parses a Soroban `ScVal` returned by a recurring-payment history view into
+ * a {@link RecurringExecutionEntry}.
+ *
+ * Expected ScvMap keys: `recurring_id`, `executed_at_ledger`, `amount`, `success`
+ *
+ * @throws {Error} if any required field is missing or has the wrong type.
+ */
+export function parseRecurringExecutionEntry(val: xdr.ScVal): RecurringExecutionEntry {
+  const map = scMapToRecord(val);
+
+  return {
+    recurringId:      scValToBigint(getField(map, 'recurring_id')),
+    executedAtLedger: scValToNumber(getField(map, 'executed_at_ledger')),
+    amount:           scValToBigint(getField(map, 'amount')),
+    success:          scValToBoolean(getField(map, 'success')),
   };
 }
 


### PR DESCRIPTION
## Summary

Implement all AdminModule write/view functions and RecurringModule.getRecurringHistory().

## Changes

- **AdminModule.mint()**: mint tokens to a recipient (admin only)
- **AdminModule.clawback()**: claw back tokens from an account (admin only)
- **AdminModule.freeze() / unfreeze()**: freeze/unfreeze accounts (admin only)
- **AdminModule.isFrozen() / isFrozenBatch()**: check frozen status
- **AdminModule.getAdmin()**: returns the current admin address
- **AdminModule.isPaused() / isContractPaused()**: check contract pause state
- **AdminModule.setAdmin()**, **pause() / unpause()**: implemented write calls
- **RecurringModule.getRecurringHistory()**: fetch execution history for a recurring payment ID
- New **RecurringExecutionEntry** type and parser

Closes #120
Closes #121
Closes #122
Closes #123