### PR TITLE
feat: add format helpers, watchEscrow, error-codes doc, contract-compatibility doc + fix workflow bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: Build, Lint, Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test -- --coverage --coverageThreshold='{"global":{"lines":80}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/contract-compatibility.md
+++ b/docs/contract-compatibility.md
@@ -1,0 +1,82 @@
+# Contract Compatibility
+
+This document describes which versions of the `veritix-contract` Soroban smart contract are
+supported by each release of the `@veritix/contract-sdk`, and how to handle version mismatches.
+
+---
+
+## Compatibility Matrix
+
+| SDK version | Contract version | Notes |
+|-------------|-----------------|-------|
+| `0.1.x`     | `1.0.x`         | Initial release — escrow, dispute, split, recurring, admin, batch |
+
+---
+
+## Checking the Deployed Contract Version
+
+Use `client.getContractMetadata()` to retrieve metadata from the live contract, including the
+version field when it is exposed:
+
+```ts
+import { VeriTixClient, getTestnetConfig } from '@veritix/contract-sdk';
+import { Keypair } from '@stellar/stellar-sdk';
+
+const client = new VeriTixClient(getTestnetConfig(process.env.CONTRACT_ID!));
+await client.connect();
+
+const metadata = await client.getContractMetadata();
+console.log('Contract ID:', metadata.contractId);
+console.log('Network:',     metadata.network);
+// name / symbol / decimal / totalSupply are also available
+```
+
+If the contract exposes a dedicated `version` entry-point, you can call it via
+`client.simulate('version', [])` and inspect the return value.
+
+---
+
+## What to Do When Versions Do Not Match
+
+If the SDK and the deployed contract are out of sync you may see:
+
+- Unexpected `UNKNOWN` errors from `parseSorobanError`.
+- Method calls that return incorrect or missing data.
+- XDR deserialisation failures.
+
+**Recommended steps:**
+
+1. Check the deployed contract version against the matrix above.
+2. If the contract is newer, upgrade to the latest SDK release:
+   ```bash
+   npm install @veritix/contract-sdk@latest
+   ```
+3. If the contract is older, pin the SDK to the compatible version:
+   ```bash
+   npm install @veritix/contract-sdk@0.1.x
+   ```
+4. If you manage the contract deployment, redeploy with the version that matches your SDK.
+
+---
+
+## Breaking Changes Between Contract Versions
+
+### Contract `1.0.x` → SDK `0.1.x`
+
+- Initial public interface — no prior version to migrate from.
+- All entry-points documented in the [README](../README.md) are stable.
+
+### Future Versions
+
+Breaking changes will be documented here with:
+
+- Which entry-points were added, changed, or removed.
+- Which SDK methods are affected.
+- A migration guide.
+
+---
+
+## Keeping in Sync
+
+Subscribe to [releases](https://github.com/Lead-Studios/veritix-contract-sdk/releases) on GitHub
+to be notified of new SDK versions. Each release tag notes the minimum compatible contract version.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,102 @@
+# Error Code Reference
+
+All SDK methods throw a `VeriTixError` when a contract-level or client-side failure occurs.
+Each error has a `code` property matching one of the `VeriTixErrorCode` enum values below.
+
+```ts
+import { VeriTixError, VeriTixErrorCode } from '@veritix/contract-sdk';
+
+try {
+  await client.escrow.releaseEscrow(1n);
+} catch (err) {
+  if (err instanceof VeriTixError) {
+    console.error(err.code, err.message);
+  }
+}
+```
+
+---
+
+## Error Code Table
+
+### Escrow
+
+| Code | Value | Thrown by | Cause | How to handle |
+|------|-------|-----------|-------|---------------|
+| `EscrowNotFound` | `ESCROW_NOT_FOUND` | `escrow.getEscrow`, `releaseEscrow`, `refundEscrow` | The escrow ID does not exist on-chain | Verify the ID is correct; treat as a user error |
+| `EscrowAlreadySettled` | `ESCROW_ALREADY_SETTLED` | `escrow.releaseEscrow`, `refundEscrow` | The escrow was already released or refunded | Check `EscrowRecord.released / refunded` before calling; safe to ignore |
+| `EscrowNotExpired` | `ESCROW_NOT_EXPIRED` | `escrow.refundEscrow` | The current ledger is still before `expiryLedger` | Wait until the ledger advances past `expiryLedger` before retrying |
+| `EscrowUnauthorized` | `ESCROW_UNAUTHORIZED` | `escrow.releaseEscrow`, `refundEscrow` | Caller is not the depositor or beneficiary | Ensure the signing `Keypair` matches the expected party |
+
+### Dispute
+
+| Code | Value | Thrown by | Cause | How to handle |
+|------|-------|-----------|-------|---------------|
+| `DisputeAlreadyOpen` | `DISPUTE_ALREADY_OPEN` | `dispute.openDispute` | A dispute already exists for this escrow | Check `DisputeRecord.status` first; safe to ignore if `Open` |
+| `DisputeNotFound` | `DISPUTE_NOT_FOUND` | `dispute.getDispute`, `resolveDispute` | The dispute ID does not exist | Verify the ID; treat as a user error |
+| `DisputeAlreadyResolved` | `DISPUTE_ALREADY_RESOLVED` | `dispute.resolveDispute` | Dispute was already resolved | No further action required |
+| `DisputeInvalidState` | `DISPUTE_INVALID_STATE` | `dispute.resolveDispute` | Dispute state does not permit this operation | Refresh the dispute record and re-evaluate |
+
+### Split
+
+| Code | Value | Thrown by | Cause | How to handle |
+|------|-------|-----------|-------|---------------|
+| `SplitNotFound` | `SPLIT_NOT_FOUND` | `splitter.getSplit`, `distribute` | The split ID does not exist | Verify the ID; treat as a user error |
+| `SplitInvalidShares` | `SPLIT_INVALID_SHARES` | `splitter.createSplit` | Recipient `shareBps` values do not sum to 10 000 | Recalculate shares so they sum exactly to 10 000 BPS |
+| `SplitAlreadyDistributed` | `SPLIT_ALREADY_DISTRIBUTED` | `splitter.distribute` | Funds were already distributed | Check `SplitRecord.distributed`; no retry needed |
+
+### Recurring
+
+| Code | Value | Thrown by | Cause | How to handle |
+|------|-------|-----------|-------|---------------|
+| `RecurringNotFound` | `RECURRING_NOT_FOUND` | `recurring.getRecurring`, `execute`, `cancel` | Recurring record does not exist | Verify the ID; treat as a user error |
+| `RecurringIntervalNotElapsed` | `RECURRING_INTERVAL_NOT_ELAPSED` | `recurring.execute` | Charge interval has not yet passed | Wait until the next interval and retry |
+
+### Token
+
+| Code | Value | Thrown by | Cause | How to handle |
+|------|-------|-----------|-------|---------------|
+| `InvalidAmount` | `INVALID_AMOUNT` | `token.mint`, `burn`, `transfer` | Amount is zero or negative | Validate amount > 0n before calling |
+| `InsufficientBalance` | `INSUFFICIENT_BALANCE` | `token.transfer`, `burn` | Account balance is too low | Check balance via `token.balance(address)` first |
+| `InsufficientAllowance` | `INSUFFICIENT_ALLOWANCE` | `token.transfer` | Spender allowance is insufficient | Call `token.approve` with an adequate amount first |
+
+### Admin
+
+| Code | Value | Thrown by | Cause | How to handle |
+|------|-------|-----------|-------|---------------|
+| `AdminUnauthorized` | `ADMIN_UNAUTHORIZED` | `admin.*` | Caller is not the contract admin | Ensure the correct admin `Keypair` is used |
+| `AccountFrozen` | `ACCOUNT_FROZEN` | `token.transfer`, `token.burn` | Target account has been frozen | Contact the admin to unfreeze; do not retry |
+| `ContractPaused` | `CONTRACT_PAUSED` | All write methods | Contract is paused by the admin | Wait for the contract to be unpaused; retry later |
+
+### Client-side / General
+
+| Code | Value | Thrown by | Cause | How to handle |
+|------|-------|-----------|-------|---------------|
+| `ConnectionFailed` | `CONNECTION_FAILED` | `client.connect()` | RPC endpoint unreachable after all retries | Check network/RPC URL; retry with backoff |
+| `ReadOnlyClient` | `READ_ONLY_CLIENT` | Any write method | No `Keypair` was provided at construction | Re-instantiate `VeriTixClient` with a `Keypair` |
+| `BatchTooLarge` | `BATCH_TOO_LARGE` | `batch.*` | Batch exceeds the maximum allowed size | Split the batch into smaller chunks |
+| `WatchTimeout` | `WATCH_TIMEOUT` | `client.watchEscrow()` | Escrow did not settle within `timeoutMs` | Increase `timeoutMs` or implement manual polling |
+| `Unauthorized` | `UNAUTHORIZED` | Various | General authorisation failure | Check that the signing key matches the expected account |
+| `Unknown` | `UNKNOWN` | Any method | Panic string could not be mapped to a known code | Log `err.rawMessage` and report as a bug |
+
+---
+
+## Accessing Raw Error Information
+
+Every `VeriTixError` exposes:
+
+- `code` — the `VeriTixErrorCode` enum value
+- `message` — a human-readable description
+- `rawMessage` — the original panic string from the Soroban RPC (useful for debugging)
+
+```ts
+catch (err) {
+  if (err instanceof VeriTixError) {
+    console.error('[code]', err.code);
+    console.error('[message]', err.message);
+    console.error('[raw]', err.rawMessage);
+  }
+}
+```
+
+You can also call `parseSorobanError(rawError)` directly when working at the Stellar SDK level.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,11 @@ import type { Config } from 'jest';
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],

--- a/package.json
+++ b/package.json
@@ -65,26 +65,5 @@
     "ts-node": "^10.9.2",
     "tsup": "^8.1.0",
     "typedoc": "^0.26.3"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.test.json"
-      }
-    },
-    "roots": [
-      "<rootDir>/tests"
-    ],
-    "testMatch": [
-      "**/*.test.ts"
-    ],
-    "collectCoverage": true,
-    "coverageDirectory": "coverage",
-    "coverageReporters": [
-      "text",
-      "lcov"
-    ]
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,7 +28,7 @@
 
 import { SorobanRpc, Keypair, xdr } from '@stellar/stellar-sdk';
 
-import type { NetworkConfig, SimulationResult, ContractMetadata } from './types/index';
+import type { NetworkConfig, SimulationResult, ContractMetadata, WatchOptions, EscrowRecord } from './types/index';
 import { buildContractCall, simulateTransaction } from './utils/transaction';
 import { EventEmitter } from 'events';
 import { VeriTixError, VeriTixErrorCode } from './utils/errors';
@@ -322,6 +322,50 @@ export class VeriTixClient extends EventEmitter {
       contractId: this.config.contractId,
       network: this.config.network,
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // watchEscrow  (#153)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Polls `getEscrow(id)` at the given interval and yields the record each
+   * time `released` or `refunded` flips to `true`.
+   *
+   * Throws a `VeriTixError` with code `WATCH_TIMEOUT` if no state change is
+   * detected within `timeoutMs`.
+   *
+   * @param id      - Escrow ID to watch.
+   * @param options - {@link WatchOptions} (intervalMs, timeoutMs).
+   *
+   * @example
+   * ```ts
+   * for await (const record of client.watchEscrow(1n)) {
+   *   console.log('Escrow settled:', record);
+   *   break;
+   * }
+   * ```
+   */
+  async *watchEscrow(id: bigint, options?: WatchOptions): AsyncIterableIterator<EscrowRecord> {
+    const intervalMs = options?.intervalMs ?? 3_000;
+    const timeoutMs = options?.timeoutMs ?? 60_000;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const record = await this.escrow.getEscrow(id);
+      if (record && (record.released || record.refunded)) {
+        yield record;
+        return;
+      }
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await new Promise<void>((resolve) => setTimeout(resolve, Math.min(intervalMs, remaining)));
+    }
+
+    throw new VeriTixError(
+      VeriTixErrorCode.WatchTimeout,
+      `watchEscrow timed out after ${timeoutMs}ms waiting for escrow ${id} to settle`,
+    );
   }
 
   // -------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export type {
   DisputeRecord,
   RecurringRecord,
   TransactionResult,
+  WatchOptions,
 } from './types/index';
 
 export { DisputeStatus } from './types/index';
@@ -71,6 +72,11 @@ export {
   TESTNET_PASSPHRASE,
   MAINNET_PASSPHRASE,
 } from './utils/network';
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+export { stroopsToXLM, xlmToStroops, formatXLM } from './utils/format';
 
 // ---------------------------------------------------------------------------
 // Transaction helpers (for advanced / custom use)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -224,6 +224,16 @@ export interface RevenueSplitParams {
 }
 
 /**
+ * Options for {@link VeriTixClient.watchEscrow}.
+ */
+export interface WatchOptions {
+  /** Polling interval in milliseconds (default 3000) */
+  intervalMs?: number;
+  /** Maximum time to wait for a state change in milliseconds (default 60000) */
+  timeoutMs?: number;
+}
+
+/**
  * Minimal representation of a submitted Stellar transaction result.
  */
 export interface TransactionResult {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -79,6 +79,8 @@ export enum VeriTixErrorCode {
   BatchTooLarge = 'BATCH_TOO_LARGE',
   /** Client has no Keypair — write operations are not available */
   ReadOnlyClient = 'READ_ONLY_CLIENT',
+  /** watchEscrow timed out before the escrow settled */
+  WatchTimeout = 'WATCH_TIMEOUT',
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +246,7 @@ function buildMessage(code: VeriTixErrorCode, rawStr: string): string {
     [VeriTixErrorCode.ConnectionFailed]:            'Failed to connect to the Soroban RPC endpoint.',
     [VeriTixErrorCode.BatchTooLarge]:               'Batch request exceeded maximum allowed size.',
     [VeriTixErrorCode.ReadOnlyClient]:              'This client is read-only. Provide a Keypair to enable write operations.',
+    [VeriTixErrorCode.WatchTimeout]:                'watchEscrow timed out before the escrow settled.',
   };
   return messages[code];
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,63 @@
+/**
+ * @module utils/format
+ * XLM ↔ stroop conversion and display-formatting helpers.
+ *
+ * 1 XLM = 10_000_000 stroops (7 decimal places).
+ */
+
+const STROOPS_PER_XLM = 10_000_000n;
+
+/**
+ * Converts a stroop amount to an XLM string with exactly 7 decimal places.
+ *
+ * @example stroopsToXLM(15_000_000n) // "1.5000000"
+ */
+export function stroopsToXLM(stroops: bigint): string {
+  if (typeof stroops !== 'bigint') throw new TypeError('stroops must be a bigint');
+  if (stroops < 0n) throw new TypeError('stroops must be non-negative');
+
+  const whole = stroops / STROOPS_PER_XLM;
+  const frac = stroops % STROOPS_PER_XLM;
+  return `${whole}.${frac.toString().padStart(7, '0')}`;
+}
+
+/**
+ * Converts an XLM amount (string or number) to stroops (bigint).
+ *
+ * @example xlmToStroops("1.5") // 15_000_000n
+ */
+export function xlmToStroops(xlm: string | number): bigint {
+  if (typeof xlm !== 'string' && typeof xlm !== 'number') {
+    throw new TypeError('xlm must be a string or number');
+  }
+  const str = String(xlm).trim();
+  if (!/^\d+(\.\d+)?$/.test(str)) throw new TypeError(`Invalid XLM value: "${str}"`);
+
+  const [wholePart, fracPart = ''] = str.split('.');
+  const frac = fracPart.slice(0, 7).padEnd(7, '0');
+  return BigInt(wholePart) * STROOPS_PER_XLM + BigInt(frac);
+}
+
+/**
+ * Formats a stroop amount as a human-readable XLM string with commas.
+ *
+ * @param stroops  - Amount in stroops.
+ * @param decimals - Number of decimal places (default 7, max 7).
+ *
+ * @example formatXLM(1_234_567_890_000n) // "123,456.7890000"
+ */
+export function formatXLM(stroops: bigint, decimals = 7): string {
+  if (typeof stroops !== 'bigint') throw new TypeError('stroops must be a bigint');
+  if (stroops < 0n) throw new TypeError('stroops must be non-negative');
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 7) {
+    throw new TypeError('decimals must be an integer between 0 and 7');
+  }
+
+  const raw = stroopsToXLM(stroops); // e.g. "123456.7890000"
+  const [whole, frac] = raw.split('.');
+  const truncatedFrac = frac.slice(0, decimals);
+
+  // Add thousands separators to the whole part
+  const withCommas = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return decimals > 0 ? `${withCommas}.${truncatedFrac}` : withCommas;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,6 +27,9 @@ export {
   scValToNumber,
 } from './scval';
 
+// XLM / stroop formatting helpers
+export { stroopsToXLM, xlmToStroops, formatXLM } from './format';
+
 // XDR struct parsers
 export {
   parseEscrowRecord,

--- a/tests/client.watchescrow.test.ts
+++ b/tests/client.watchescrow.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @file tests/client.watchescrow.test.ts
+ * Unit tests for VeriTixClient.watchEscrow() using fake timers.
+ */
+
+import { VeriTixClient } from '../src/client';
+import { VeriTixErrorCode } from '../src/utils/errors';
+import { getTestnetConfig } from '../src/utils/network';
+import type { EscrowRecord } from '../src/types/index';
+
+const FAKE_CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+
+function makeRecord(overrides: Partial<EscrowRecord> = {}): EscrowRecord {
+  return {
+    id: 1n,
+    depositor: 'GABC',
+    beneficiary: 'GDEF',
+    amount: 10_000_000n,
+    released: false,
+    refunded: false,
+    expiryLedger: 999_999,
+    memos: [],
+    ...overrides,
+  };
+}
+
+function makeClient() {
+  const client = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT_ID));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (client as any).connected = true;
+  return client;
+}
+
+describe('watchEscrow()', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('yields record immediately when escrow is already released', async () => {
+    const client = makeClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue(makeRecord({ released: true }));
+
+    const results: EscrowRecord[] = [];
+    for await (const r of client.watchEscrow(1n)) {
+      results.push(r);
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0].released).toBe(true);
+  });
+
+  it('yields record when escrow is already refunded', async () => {
+    const client = makeClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue(makeRecord({ refunded: true }));
+
+    const results: EscrowRecord[] = [];
+    for await (const r of client.watchEscrow(1n)) {
+      results.push(r);
+    }
+
+    expect(results[0].refunded).toBe(true);
+  });
+
+  it('polls and yields once state changes to released', async () => {
+    const client = makeClient();
+    let calls = 0;
+    jest.spyOn(client.escrow, 'getEscrow').mockImplementation(async () => {
+      calls++;
+      if (calls >= 2) return makeRecord({ released: true });
+      return makeRecord();
+    });
+
+    const watchPromise = (async () => {
+      const results: EscrowRecord[] = [];
+      for await (const r of client.watchEscrow(1n, { intervalMs: 100, timeoutMs: 5_000 })) {
+        results.push(r);
+      }
+      return results;
+    })();
+
+    // Advance timers to trigger the polling interval
+    await Promise.resolve();
+    jest.advanceTimersByTime(200);
+    await Promise.resolve();
+
+    const results = await watchPromise;
+    expect(results).toHaveLength(1);
+    expect(results[0].released).toBe(true);
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it('throws VeriTixError with WatchTimeout code when timeout expires', async () => {
+    const client = makeClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue(makeRecord());
+
+    const watchPromise = (async () => {
+      for await (const _ of client.watchEscrow(1n, { intervalMs: 100, timeoutMs: 200 })) {
+        // should not yield
+      }
+    })();
+
+    // Advance past timeout
+    await Promise.resolve();
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+
+    await expect(watchPromise).rejects.toMatchObject({
+      code: VeriTixErrorCode.WatchTimeout,
+    });
+  });
+});

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @file tests/utils/format.test.ts
+ * Unit tests for stroopsToXLM, xlmToStroops, and formatXLM.
+ */
+
+import { stroopsToXLM, xlmToStroops, formatXLM } from '../../src/utils/format';
+
+describe('stroopsToXLM', () => {
+  it('converts zero', () => {
+    expect(stroopsToXLM(0n)).toBe('0.0000000');
+  });
+
+  it('converts exactly 1 XLM', () => {
+    expect(stroopsToXLM(10_000_000n)).toBe('1.0000000');
+  });
+
+  it('converts 1.5 XLM', () => {
+    expect(stroopsToXLM(15_000_000n)).toBe('1.5000000');
+  });
+
+  it('pads fractional part to 7 digits', () => {
+    expect(stroopsToXLM(1n)).toBe('0.0000001');
+  });
+
+  it('handles large values', () => {
+    expect(stroopsToXLM(1_000_000_000_000_000n)).toBe('100000000.0000000');
+  });
+
+  it('throws TypeError for negative stroops', () => {
+    expect(() => stroopsToXLM(-1n)).toThrow(TypeError);
+  });
+
+  it('throws TypeError for non-bigint input', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => stroopsToXLM(123 as any)).toThrow(TypeError);
+  });
+});
+
+describe('xlmToStroops', () => {
+  it('converts "1" to 10_000_000n', () => {
+    expect(xlmToStroops('1')).toBe(10_000_000n);
+  });
+
+  it('converts "1.5" to 15_000_000n', () => {
+    expect(xlmToStroops('1.5')).toBe(15_000_000n);
+  });
+
+  it('converts "0.0000001" to 1n', () => {
+    expect(xlmToStroops('0.0000001')).toBe(1n);
+  });
+
+  it('converts number input', () => {
+    expect(xlmToStroops(2)).toBe(20_000_000n);
+  });
+
+  it('truncates extra decimal places beyond 7', () => {
+    expect(xlmToStroops('1.12345678')).toBe(xlmToStroops('1.1234567'));
+  });
+
+  it('converts "0" to 0n', () => {
+    expect(xlmToStroops('0')).toBe(0n);
+  });
+
+  it('throws TypeError for negative string', () => {
+    expect(() => xlmToStroops('-1')).toThrow(TypeError);
+  });
+
+  it('throws TypeError for non-numeric string', () => {
+    expect(() => xlmToStroops('abc')).toThrow(TypeError);
+  });
+
+  it('throws TypeError for non-string/number input', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => xlmToStroops(null as any)).toThrow(TypeError);
+  });
+});
+
+describe('formatXLM', () => {
+  it('formats with commas and 7 decimals by default', () => {
+    expect(formatXLM(1_234_567_890_000n)).toBe('123,456.7890000');
+  });
+
+  it('formats zero', () => {
+    expect(formatXLM(0n)).toBe('0.0000000');
+  });
+
+  it('formats with custom decimal places', () => {
+    expect(formatXLM(10_000_000n, 2)).toBe('1.00');
+  });
+
+  it('formats with 0 decimals', () => {
+    expect(formatXLM(10_000_000n, 0)).toBe('1');
+  });
+
+  it('formats large amounts with commas', () => {
+    expect(formatXLM(1_000_000_000_000_000n, 0)).toBe('100,000,000');
+  });
+
+  it('throws TypeError for negative stroops', () => {
+    expect(() => formatXLM(-1n)).toThrow(TypeError);
+  });
+
+  it('throws TypeError for invalid decimals', () => {
+    expect(() => formatXLM(10_000_000n, 8)).toThrow(TypeError);
+    expect(() => formatXLM(10_000_000n, -1)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes workflow configuration bugs and implements issues #145, #149, #152, and #153.

## Changes

### Workflow fixes
- **Removed duplicate Jest configuration** from `package.json` (was conflicting with `jest.config.ts`)
- **Added CI/Release workflow files** to `.github/workflows/` (were incorrectly placed in `docs/workflows/`)
- Updated `jest.config.ts` with proper `ts-jest` globals and tsconfig path

### Issue #152 — XLM/stroop format helpers
- Added `stroopsToXLM`, `xlmToStroops`, `formatXLM` to `src/utils/format.ts`
- Exported from `src/utils/index.ts` and `src/index.ts`
- Full unit test coverage in `tests/utils/format.test.ts`

### Issue #153 — `watchEscrow()`
- Added `WatchOptions` interface to `src/types/index.ts`
- Added `VeriTixClient.watchEscrow(id, options?)` — async generator that polls `getEscrow` and yields on state change
- Added `VeriTixErrorCode.WatchTimeout` error code
- Tests with fake timers in `tests/client.watchescrow.test.ts`

### Issue #145 — Error code reference
- Created `docs/error-codes.md` with a full table for every `VeriTixErrorCode`

### Issue #149 — Contract compatibility
- Created `docs/contract-compatibility.md` with SDK×Contract version matrix and migration guidance

## Testing

All new tests pass. Pre-existing failures in `dispute.test.ts`, `escrow.test.ts`, and `transaction.test.ts` are unrelated to this PR.

Closes #145
Closes #149
Closes #152
Closes #153