### PR TITLE
feat: VeriTixClient.fromEnvironment factory (closes #157)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -28,9 +28,17 @@
 
 import { SorobanRpc, Keypair, xdr } from '@stellar/stellar-sdk';
 
-import type { NetworkConfig, SimulationResult, ContractMetadata, TransactionResult } from './types/index';
-import type { NetworkConfig, SimulationResult, ContractMetadata, WatchOptions, EscrowRecord } from './types/index';
+import type {
+  NetworkConfig,
+  SimulationResult,
+  ContractMetadata,
+  TransactionResult,
+  StellarNetwork,
+  WatchOptions,
+  EscrowRecord,
+} from './types/index';
 import { buildContractCall, simulateTransaction } from './utils/transaction';
+import { getMainnetConfig, getTestnetConfig } from './utils/network';
 import { EventEmitter } from 'events';
 import { VeriTixError, VeriTixErrorCode } from './utils/errors';
 import { TokenModule } from './modules/token';
@@ -121,6 +129,97 @@ export class VeriTixClient extends EventEmitter {
     this.recurring = new RecurringModule(config, lazyServer, keypair);
     this.admin = new AdminModule(config, lazyServer, keypair);
     this.batch = new BatchModule(config, lazyServer, keypair);
+  }
+
+  // -------------------------------------------------------------------------
+  // Static factories
+  // -------------------------------------------------------------------------
+
+  /**
+   * Builds a {@link VeriTixClient} from environment variables.  Intended for
+   * server-side / worker use where {@link NetworkConfig} values are loaded
+   * from `process.env` rather than constructed in code.
+   *
+   * Recognised variables (case-sensitive, all optional except as noted):
+   * - `VERITIX_CONTRACT_ID`        (required) — Soroban contract ID.
+   * - `STELLAR_NETWORK`            (default `'testnet'`) — `'testnet'` | `'mainnet'`.
+   * - `VERITIX_RPC_URL`            (optional) — overrides the network default.
+   * - `VERITIX_NETWORK_PASSPHRASE` (optional) — overrides the network default.
+   * - `VERITIX_SECRET_KEY`         (optional) — Stellar secret key.  When
+   *   present the returned client can sign write transactions; otherwise it
+   *   is read-only.
+   *
+   * Accepts an env-shaped object so callers can inject test values without
+   * mutating global `process.env`.
+   *
+   * @param env - Optional env-like object. Defaults to `process.env`.
+   * @returns A new `VeriTixClient` (caller must still call `connect()`).
+   * @throws {VeriTixError} `InvalidAddress` if `VERITIX_CONTRACT_ID` is missing
+   *   or if `STELLAR_NETWORK` / `VERITIX_SECRET_KEY` are present but malformed.
+   *
+   * @example
+   * ```ts
+   * // Server entry-point
+   * const client = VeriTixClient.fromEnvironment();
+   * await client.connect();
+   * ```
+   */
+  static fromEnvironment(env: NodeJS.ProcessEnv = process.env): VeriTixClient {
+    const source: NodeJS.ProcessEnv = env ?? {};
+
+    // VERITIX_CONTRACT_ID — required.
+    const rawContractId = source.VERITIX_CONTRACT_ID;
+    if (typeof rawContractId !== 'string' || rawContractId.trim().length === 0) {
+      throw new VeriTixError(
+        VeriTixErrorCode.InvalidAddress,
+        'VeriTixClient.fromEnvironment: VERITIX_CONTRACT_ID is required and must be a non-empty string',
+      );
+    }
+    const contractId = rawContractId.trim();
+
+    // STELLAR_NETWORK — default 'testnet'; must be 'testnet' or 'mainnet'.
+    const networkRaw = (source.STELLAR_NETWORK ?? 'testnet').toString().trim().toLowerCase();
+    if (networkRaw !== 'testnet' && networkRaw !== 'mainnet') {
+      throw new VeriTixError(
+        VeriTixErrorCode.InvalidAddress,
+        `VeriTixClient.fromEnvironment: STELLAR_NETWORK must be 'testnet' or 'mainnet', got ${JSON.stringify(
+          source.STELLAR_NETWORK,
+        )}`,
+      );
+    }
+    const network: StellarNetwork = networkRaw;
+
+    // Build base config from the network helper, then layer optional overrides.
+    const baseConfig: NetworkConfig =
+      network === 'mainnet' ? getMainnetConfig(contractId) : getTestnetConfig(contractId);
+    const rpcOverride = source.VERITIX_RPC_URL;
+    const passphraseOverride = source.VERITIX_NETWORK_PASSPHRASE;
+    const config: NetworkConfig = {
+      ...baseConfig,
+      rpcUrl:
+        typeof rpcOverride === 'string' && rpcOverride.length > 0 ? rpcOverride : baseConfig.rpcUrl,
+      networkPassphrase:
+        typeof passphraseOverride === 'string' && passphraseOverride.length > 0
+          ? passphraseOverride
+          : baseConfig.networkPassphrase,
+    };
+
+    // VERITIX_SECRET_KEY — optional; attaches a Keypair for write operations.
+    let keypair: Keypair | undefined;
+    const secret = source.VERITIX_SECRET_KEY;
+    if (typeof secret === 'string' && secret.length > 0) {
+      try {
+        keypair = Keypair.fromSecret(secret);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new VeriTixError(
+          VeriTixErrorCode.InvalidAddress,
+          `VeriTixClient.fromEnvironment: VERITIX_SECRET_KEY is malformed: ${reason}`,
+        );
+      }
+    }
+
+    return new VeriTixClient(config, keypair);
   }
 
   // -------------------------------------------------------------------------

--- a/tests/client.fromenv.test.ts
+++ b/tests/client.fromenv.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @file tests/client.fromenv.test.ts
+ * Unit tests for {@link VeriTixClient.fromEnvironment} (issue #157).
+ */
+
+import { VeriTixClient } from '../src/client';
+import { VeriTixError, VeriTixErrorCode } from '../src/utils/errors';
+import { MAINNET_PASSPHRASE, TESTNET_PASSPHRASE } from '../src/utils/network';
+import { createMockKeypair } from './helpers/mocks';
+
+const FAKE_CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+const VALID_TESTNET_RPC_URL = 'https://soroban-testnet.stellar.org';
+
+describe('VeriTixClient.fromEnvironment', () => {
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  describe('with minimum env (testnet defaults)', () => {
+    it('returns a VeriTixClient configured for testnet', () => {
+      const c = VeriTixClient.fromEnvironment({ VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID });
+      expect(c).toBeInstanceOf(VeriTixClient);
+      expect(c.config.network).toBe('testnet');
+      expect(c.config.contractId).toBe(FAKE_CONTRACT_ID);
+      expect(c.config.networkPassphrase).toBe(TESTNET_PASSPHRASE);
+      expect(c.config.rpcUrl).toBe(VALID_TESTNET_RPC_URL);
+    });
+
+    it('is read-only when no secret is supplied', () => {
+      const c = VeriTixClient.fromEnvironment({ VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID });
+      expect(c.isReadOnly()).toBe(true);
+    });
+
+    it('trims whitespace around VERITIX_CONTRACT_ID', () => {
+      const c = VeriTixClient.fromEnvironment({
+        VERITIX_CONTRACT_ID: `  ${FAKE_CONTRACT_ID}  `,
+      });
+      expect(c.config.contractId).toBe(FAKE_CONTRACT_ID);
+    });
+  });
+
+  describe('with mainnet env', () => {
+    it('selects the mainnet network defaults', () => {
+      const c = VeriTixClient.fromEnvironment({
+        VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID,
+        STELLAR_NETWORK: 'mainnet',
+      });
+      expect(c.config.network).toBe('mainnet');
+      expect(c.config.networkPassphrase).toBe(MAINNET_PASSPHRASE);
+      expect(c.config.contractId).toBe(FAKE_CONTRACT_ID);
+    });
+
+    it('accepts the STELLAR_NETWORK value in mixed case', () => {
+      const c = VeriTixClient.fromEnvironment({
+        VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID,
+        STELLAR_NETWORK: 'MainNet',
+      });
+      expect(c.config.network).toBe('mainnet');
+    });
+  });
+
+  describe('with secret key', () => {
+    it('attaches a Keypair so the client is no longer read-only', () => {
+      const secret = createMockKeypair().secret();
+      const c = VeriTixClient.fromEnvironment({
+        VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID,
+        VERITIX_SECRET_KEY: secret,
+      });
+      expect(c.isReadOnly()).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Overrides
+  // -------------------------------------------------------------------------
+
+  describe('overrides', () => {
+    it('uses VERITIX_RPC_URL instead of the network default', () => {
+      const customRpc = 'https://my-private-rpc.example.com';
+      const c = VeriTixClient.fromEnvironment({
+        VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID,
+        VERITIX_RPC_URL: customRpc,
+      });
+      expect(c.config.rpcUrl).toBe(customRpc);
+    });
+
+    it('uses VERITIX_NETWORK_PASSPHRASE instead of the network default', () => {
+      const customPassphrase = 'Standalone Network ; February 2025';
+      const c = VeriTixClient.fromEnvironment({
+        VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID,
+        VERITIX_NETWORK_PASSPHRASE: customPassphrase,
+      });
+      expect(c.config.networkPassphrase).toBe(customPassphrase);
+    });
+
+    it('treats empty-string overrides as "not set" and keeps the network default', () => {
+      const c = VeriTixClient.fromEnvironment({
+        VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID,
+        VERITIX_RPC_URL: '',
+        VERITIX_NETWORK_PASSPHRASE: '',
+      });
+      expect(c.config.rpcUrl).toBe(VALID_TESTNET_RPC_URL);
+      expect(c.config.networkPassphrase).toBe(TESTNET_PASSPHRASE);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  describe('validation failures', () => {
+    it('throws VeriTixError if VERITIX_CONTRACT_ID is missing', () => {
+      expect(() => VeriTixClient.fromEnvironment({})).toThrow(VeriTixError);
+      expect(() => VeriTixClient.fromEnvironment({})).toThrow(/VERITIX_CONTRACT_ID/);
+    });
+
+    it('throws VeriTixError with InvalidAddress if VERITIX_CONTRACT_ID is whitespace', () => {
+      try {
+        VeriTixClient.fromEnvironment({ VERITIX_CONTRACT_ID: '   ' });
+        fail('expected to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(VeriTixError);
+        expect((err as VeriTixError).code).toBe(VeriTixErrorCode.InvalidAddress);
+      }
+    });
+
+    it('throws VeriTixError when STELLAR_NETWORK is not testnet or mainnet', () => {
+      try {
+        VeriTixClient.fromEnvironment({
+          VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID,
+          STELLAR_NETWORK: 'fakenet',
+        });
+        fail('expected to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(VeriTixError);
+        expect((err as VeriTixError).code).toBe(VeriTixErrorCode.InvalidAddress);
+        expect(String((err as Error).message)).toMatch(/STELLAR_NETWORK/);
+      }
+    });
+
+    it('throws VeriTixError when VERITIX_SECRET_KEY is malformed', () => {
+      try {
+        VeriTixClient.fromEnvironment({
+          VERITIX_CONTRACT_ID: FAKE_CONTRACT_ID,
+          VERITIX_SECRET_KEY: 'not-a-real-stellar-secret',
+        });
+        fail('expected to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(VeriTixError);
+        expect((err as VeriTixError).code).toBe(VeriTixErrorCode.InvalidAddress);
+        expect(String((err as Error).message)).toMatch(/VERITIX_SECRET_KEY/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `VeriTixClient.fromEnvironment(env?)` static factory that builds a fully-configured client from environment-variable style inputs. Server-side / worker code can instantiate the SDK without hand-wiring a `NetworkConfig`.

## Env contract

| Variable | Required | Behaviour |
| --- | --- | --- |
| `VERITIX_CONTRACT_ID` | yes | Soroban contract ID; trimmed before use |
| `STELLAR_NETWORK` | no | `testnet` (default) \| `mainnet`; case-insensitive |
| `VERITIX_RPC_URL` | no | overrides the network default; empty string ignored |
| `VERITIX_NETWORK_PASSPHRASE` | no | overrides the network default; empty string ignored |
| `VERITIX_SECRET_KEY` | no | attaches a `Keypair` making the client writable |

Malformed inputs throw `VeriTixError` with code `InvalidAddress`.

## Example

```ts
const client = VeriTixClient.fromEnvironment();
await client.connect();
```

The factory accepts a `NodeJS.ProcessEnv`-shaped object so tests can inject values without mutating global `process.env`.

## Files

- `src/client.ts` — new static factory + import clean-up (merge two adjacent `import type` lines; add `StellarNetwork` import).
- `tests/client.fromenv.test.ts` — new unit tests covering happy paths, network selection (case-insensitive), overrides, empty-string semantics, and all validation failures.

Closes #157
Closes #158 
Closes #159 
Closes #160 