### PR TITLE
fix(token): short-circuit isFrozen for contract address (#209)

### DIFF
--- a/src/modules/token.ts
+++ b/src/modules/token.ts
@@ -278,6 +278,14 @@ export class TokenModule {
    * ```
    */
   async isFrozen(address: string): Promise<boolean> {
+    // Pre-flight (issue #209): the contract address itself is never
+    // subject to per-account freezes — return false immediately without
+    // an RPC round-trip so callers asking "is the contract frozen?" are
+    // not charged a ledger read.
+    if (address === this.config.contractId) {
+      return false;
+    }
+
     try {
       const result = await this.simulateRead('is_frozen', [
         nativeToScVal(Address.fromString(address), { type: 'address' }),


### PR DESCRIPTION
## Summary

Adds a pre-flight guard in `TokenModule.isFrozen(address)` that returns `false` immediately when `address === this.config.contractId` — the contract address is never subject to per-account freezes by design, so no RPC round-trip is needed.

## Behaviour

| input | before | after |
| --- | --- | --- |
| `isFrozen(contractId)` | simulate `is_frozen` on-chain | returns `false` synchronously |
| `isFrozen(<other account>)` | simulate `is_frozen` on-chain | unchanged |

## Files

- `src/modules/token.ts` — single guard inserted at the top of `isFrozen`.

Closes #209
Closes #207 
Closes #208 
Closes #210 