### PR TITLE
fix(escrow): throw VeriTixError(ReadOnlyClient) when no keypair for createEscrow (#213)

### DIFF
--- a/src/modules/escrow.ts
+++ b/src/modules/escrow.ts
@@ -255,7 +255,10 @@ export class EscrowModule {
     params: CreateEscrowParams,
   ): Promise<TransactionResult & { escrowId: bigint }> {
     if (!this.keypair) {
-      throw new Error('EscrowModule.createEscrow: signing keypair required');
+      throw new VeriTixError(
+        VeriTixErrorCode.ReadOnlyClient,
+        'EscrowModule.createEscrow: signing keypair required',
+      );
     }
 
     if (params.amount <= 0n) {


### PR DESCRIPTION
## Summary

`EscrowModule.createEscrow` raised a plain `Error` when the client was constructed without a `Keypair`. Every other write method in the SDK throws a `VeriTixError` with a typed `VeriTixErrorCode`, so the inconsistency forced callers to also catch plain `Error` to handle the read-only check.

This change replaces the plain `Error` with `throw new VeriTixError(VeriTixErrorCode.ReadOnlyClient, …)`, restoring the uniform typed-error contract.

Closes #213
Closes #212 
Closes #211 
Closes #214 