### PR TITLE
Add EscrowModule.transferBeneficiary() method

### DIFF
--- a/src/modules/escrow.ts
+++ b/src/modules/escrow.ts
@@ -365,6 +365,96 @@ export class EscrowModule {
     return this.settleEscrow('refund_escrow', id);
   }
 
+  /**
+   * Transfers the beneficiary role of an escrow to a new address.
+   * Must be called by the depositor. The new beneficiary must be a valid
+   * Stellar address and must differ from the depositor.
+   *
+   * @param escrowId      - Numeric escrow identifier.
+   * @param newBeneficiary - Stellar account address of the new beneficiary.
+   * @returns A {@link TransactionResult} on success.
+   * @throws {VeriTixError} With code `ESCROW_NOT_FOUND` if the escrow does not exist.
+   * @throws {VeriTixError} With code `ESCROW_ALREADY_SETTLED` if already settled.
+   * @throws {VeriTixError} With code `ESCROW_UNAUTHORIZED` if caller is not the depositor.
+   * @throws {VeriTixError} With code `INVALID_ADDRESS` if newBeneficiary is malformed.
+   * @throws {VeriTixError} With code `INVALID_BENEFICIARY` if newBeneficiary equals the depositor.
+   *
+   * @example
+   * ```ts
+   * const result = await client.escrow.transferBeneficiary(1n, 'GNEW…');
+   * console.log('Beneficiary transferred in tx:', result.hash);
+   * ```
+   */
+  async transferBeneficiary(escrowId: bigint, newBeneficiary: string): Promise<TransactionResult> {
+    if (!this.keypair) {
+      throw new VeriTixError(
+        VeriTixErrorCode.ReadOnlyClient,
+        'EscrowModule.transferBeneficiary: signing keypair required',
+      );
+    }
+
+    try {
+      new Address(newBeneficiary);
+    } catch {
+      throw new VeriTixError(
+        VeriTixErrorCode.InvalidAddress,
+        'EscrowModule.transferBeneficiary: newBeneficiary must be a valid Stellar address',
+      );
+    }
+
+    const escrow = await this.getEscrow(escrowId);
+    if (!escrow) {
+      throw new VeriTixError(VeriTixErrorCode.EscrowNotFound, 'Escrow not found');
+    }
+
+    if (escrow.released || escrow.refunded) {
+      throw new VeriTixError(
+        VeriTixErrorCode.EscrowAlreadySettled,
+        'Escrow has already been released or refunded',
+      );
+    }
+
+    const caller = this.keypair.publicKey();
+    if (caller !== escrow.depositor) {
+      throw new VeriTixError(
+        VeriTixErrorCode.EscrowUnauthorized,
+        'EscrowModule.transferBeneficiary: caller is not the depositor',
+      );
+    }
+
+    if (newBeneficiary === caller) {
+      throw new VeriTixError(
+        VeriTixErrorCode.InvalidBeneficiary,
+        'EscrowModule.transferBeneficiary: newBeneficiary must not be the same as the depositor',
+      );
+    }
+
+    const tx = await buildContractCall(
+      this.server,
+      new Account(caller, '0'),
+      this.config.contractId,
+      'transfer_beneficiary',
+      [bigintToScVal(escrowId, 'u64'), addressToScVal(newBeneficiary)],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result ? raw.result.retval : undefined;
+
+    const assembled = SorobanRpc.assembleTransaction(tx, raw).build();
+    const result = await submitTransaction(this.server, assembled, this.keypair);
+
+    return {
+      ...result,
+      returnValue,
+    };
+  }
+
   private async getEscrowIdsByAddress(
     method: 'escrows_by_depositor' | 'escrows_by_beneficiary',
     address: string,

--- a/tests/escrow.test.ts
+++ b/tests/escrow.test.ts
@@ -346,6 +346,100 @@ describe('EscrowModule (stubs)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// transferBeneficiary tests
+// ---------------------------------------------------------------------------
+
+describe('EscrowModule.transferBeneficiary', () => {
+  it('rejects when no signing keypair is provided', async () => {
+    const { client } = makeConnectedClient();
+    await expect(client.escrow.transferBeneficiary(1n, FAKE_ADDRESS)).rejects.toThrow(
+      'signing keypair required',
+    );
+  });
+
+  it('throws INVALID_ADDRESS when newBeneficiary is malformed', async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    await expect(client.escrow.transferBeneficiary(1n, 'not-a-valid-address')).rejects.toMatchObject({
+      code: VeriTixErrorCode.InvalidAddress,
+    });
+  });
+
+  it('throws ESCROW_NOT_FOUND when escrow does not exist', async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue(null);
+    await expect(client.escrow.transferBeneficiary(1n, FAKE_ADDRESS)).rejects.toMatchObject({
+      code: VeriTixErrorCode.EscrowNotFound,
+    });
+  });
+
+  it('throws ESCROW_ALREADY_SETTLED when escrow is released', async () => {
+    const { client } = makeConnectedClient(Keypair.random());
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: true, refunded: false, expiryLedger: 1_005_000, memos: [],
+    });
+    await expect(client.escrow.transferBeneficiary(1n, FAKE_ADDRESS)).rejects.toMatchObject({
+      code: VeriTixErrorCode.EscrowAlreadySettled,
+    });
+  });
+
+  it('throws ESCROW_UNAUTHORIZED when caller is not the depositor', async () => {
+    const keypair = Keypair.random();
+    const { client } = makeConnectedClient(keypair);
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: false, expiryLedger: 1_005_000, memos: [],
+    });
+    await expect(client.escrow.transferBeneficiary(1n, FAKE_ADDRESS)).rejects.toMatchObject({
+      code: VeriTixErrorCode.EscrowUnauthorized,
+    });
+  });
+
+  it('throws INVALID_BENEFICIARY when newBeneficiary equals the depositor', async () => {
+    const keypair = Keypair.random();
+    const { client } = makeConnectedClient(keypair);
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: keypair.publicKey(), beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: false, expiryLedger: 1_005_000, memos: [],
+    });
+    await expect(client.escrow.transferBeneficiary(1n, keypair.publicKey())).rejects.toMatchObject({
+      code: VeriTixErrorCode.InvalidBeneficiary,
+    });
+  });
+
+  it('submits the transfer_beneficiary transaction successfully', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    const fakeTx = { id: 'unsigned' } as never;
+    const fakeAssembledTx = { id: 'assembled' } as never;
+
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: keypair.publicKey(), beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: false, expiryLedger: 1_005_000, memos: [],
+    });
+    jest.spyOn(transactionUtils, 'buildContractCall').mockResolvedValue(fakeTx);
+    jest.spyOn(SorobanRpc, 'assembleTransaction').mockReturnValue({
+      build: () => fakeAssembledTx,
+    } as never);
+    jest.spyOn(transactionUtils, 'submitTransaction').mockResolvedValue({
+      hash: 'transfer-hash', ledger: 200, successful: true,
+    });
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS', result: { retval: xdr.ScVal.scvVoid() },
+    });
+
+    const newBeneficiary = Keypair.random().publicKey();
+    const result = await client.escrow.transferBeneficiary(1n, newBeneficiary);
+
+    expect(result).toMatchObject({ hash: 'transfer-hash', ledger: 200, successful: true });
+    expect(transactionUtils.buildContractCall).toHaveBeenCalledWith(
+      mockServer, expect.anything(), FAKE_CONTRACT, 'transfer_beneficiary',
+      expect.any(Array), getTestnetConfig(FAKE_CONTRACT).networkPassphrase,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // getEscrowsBatch validation tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implemented a production-ready 	ransferBeneficiary() method in EscrowModule while maintaining the existing architecture and coding standards.

### Changes

- Added 	ransferBeneficiary(escrowId, newBeneficiary) to EscrowModule`n- Pre-flight validates new address, caller is depositor, escrow not settled`n- Calls contract 	ransfer_beneficiary`n- Added unit tests for all validation paths and successful submission`n- Verified linting`n- Verified build`n- Ensured no unrelated changes were introduced`n
Closes #227