### PR TITLE
Add EscrowModule.triggerAutoRelease() for keeper bots

### DIFF
--- a/src/modules/escrow.ts
+++ b/src/modules/escrow.ts
@@ -365,6 +365,74 @@ export class EscrowModule {
     return this.settleEscrow('refund_escrow', id);
   }
 
+  /**
+   * Triggers automatic release of an escrow after its expiry deadline.
+   * Callable by anyone (e.g. a keeper bot) — no signing keypair required.
+   * The escrow must have reached its `expiryLedger` and must not already be
+   * settled (released or refunded).
+   *
+   * @param id             - Numeric escrow identifier.
+   * @param currentLedger  - Optional current ledger sequence. If not provided, fetches from the server.
+   * @returns A {@link TransactionResult} on success.
+   * @throws {VeriTixError} With code `ESCROW_NOT_FOUND` if the escrow does not exist.
+   * @throws {VeriTixError} With code `ESCROW_ALREADY_SETTLED` if already settled.
+   * @throws {VeriTixError} With code `ESCROW_NOT_EXPIRED` if the expiry ledger has not been reached.
+   *
+   * @example
+   * ```ts
+   * // Keeper bot triggers auto-release after deadline
+   * const result = await client.escrow.triggerAutoRelease(1n);
+   * console.log('Auto-released in tx:', result.hash);
+   * ```
+   */
+  async triggerAutoRelease(id: bigint, currentLedger?: number): Promise<TransactionResult> {
+    const escrow = await this.getEscrow(id);
+    if (!escrow) {
+      throw new VeriTixError(VeriTixErrorCode.EscrowNotFound, 'Escrow not found');
+    }
+
+    if (escrow.released || escrow.refunded) {
+      throw new VeriTixError(
+        VeriTixErrorCode.EscrowAlreadySettled,
+        'Escrow has already been released or refunded',
+      );
+    }
+
+    const ledger = currentLedger ?? (await this.server.getLatestLedger()).sequence;
+    if (ledger < escrow.expiryLedger) {
+      throw new VeriTixError(
+        VeriTixErrorCode.EscrowNotExpired,
+        'Escrow has not yet reached its expiry ledger',
+      );
+    }
+
+    const sourceAccount = new Account(DUMMY_PUBLIC_KEY, '0');
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      'trigger_auto_release',
+      [bigintToScVal(id, 'u64')],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result ? raw.result.retval : undefined;
+
+    const assembled = SorobanRpc.assembleTransaction(tx, raw).build();
+    const result = await submitTransaction(this.server, assembled, undefined);
+
+    return {
+      ...result,
+      returnValue,
+    };
+  }
+
   private async getEscrowIdsByAddress(
     method: 'escrows_by_depositor' | 'escrows_by_beneficiary',
     address: string,

--- a/tests/escrow.test.ts
+++ b/tests/escrow.test.ts
@@ -629,6 +629,101 @@ describe('EscrowModule.isExpired', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// triggerAutoRelease tests
+// ---------------------------------------------------------------------------
+
+describe('EscrowModule.triggerAutoRelease', () => {
+  const EXPIRY_LEDGER = 1_000_000;
+
+  it('throws ESCROW_NOT_FOUND when escrow does not exist', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue(null);
+    await expect(client.escrow.triggerAutoRelease(1n, EXPIRY_LEDGER)).rejects.toMatchObject({
+      code: VeriTixErrorCode.EscrowNotFound,
+    });
+  });
+
+  it('throws ESCROW_ALREADY_SETTLED when escrow is released', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: true, refunded: false, expiryLedger: EXPIRY_LEDGER, memos: [],
+    });
+    await expect(client.escrow.triggerAutoRelease(1n, EXPIRY_LEDGER)).rejects.toMatchObject({
+      code: VeriTixErrorCode.EscrowAlreadySettled,
+    });
+  });
+
+  it('throws ESCROW_ALREADY_SETTLED when escrow is refunded', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: true, expiryLedger: EXPIRY_LEDGER, memos: [],
+    });
+    await expect(client.escrow.triggerAutoRelease(1n, EXPIRY_LEDGER)).rejects.toMatchObject({
+      code: VeriTixErrorCode.EscrowAlreadySettled,
+    });
+  });
+
+  it('throws ESCROW_NOT_EXPIRED when current ledger is before expiry', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: false, expiryLedger: EXPIRY_LEDGER, memos: [],
+    });
+    await expect(client.escrow.triggerAutoRelease(1n, EXPIRY_LEDGER - 1)).rejects.toMatchObject({
+      code: VeriTixErrorCode.EscrowNotExpired,
+    });
+  });
+
+  it('succeeds when current ledger equals expiry ledger', async () => {
+    const { client, mockServer } = makeConnectedClient();
+    const fakeTx = { id: 'unsigned' } as never;
+    const fakeAssembledTx = { id: 'assembled' } as never;
+
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: false, expiryLedger: EXPIRY_LEDGER, memos: [],
+    });
+    jest.spyOn(transactionUtils, 'buildContractCall').mockResolvedValue(fakeTx);
+    jest.spyOn(SorobanRpc, 'assembleTransaction').mockReturnValue({
+      build: () => fakeAssembledTx,
+    } as never);
+    jest.spyOn(transactionUtils, 'submitTransaction').mockResolvedValue({
+      hash: 'auto-release-hash', ledger: 200, successful: true,
+    });
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS', result: { retval: xdr.ScVal.scvVoid() },
+    });
+
+    const result = await client.escrow.triggerAutoRelease(1n, EXPIRY_LEDGER);
+    expect(result).toMatchObject({ hash: 'auto-release-hash', ledger: 200, successful: true });
+  });
+
+  it('does not require a signing keypair', async () => {
+    const { client, mockServer } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: false, expiryLedger: EXPIRY_LEDGER, memos: [],
+    });
+    jest.spyOn(transactionUtils, 'buildContractCall').mockResolvedValue({} as never);
+    jest.spyOn(SorobanRpc, 'assembleTransaction').mockReturnValue({
+      build: () => ({} as never),
+    } as never);
+    jest.spyOn(transactionUtils, 'submitTransaction').mockResolvedValue({
+      hash: 'hash', ledger: 100, successful: true,
+    });
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS', result: { retval: xdr.ScVal.scvVoid() },
+    });
+
+    // Should not throw ReadOnlyClient even without keypair
+    const result = await client.escrow.triggerAutoRelease(1n, EXPIRY_LEDGER);
+    expect(result.successful).toBe(true);
+  });
+});
+
 describe('EscrowModule.settleEvent', () => {
   const keypair = Keypair.random();
 


### PR DESCRIPTION
## Summary

Implemented 	riggerAutoRelease() - a keeper-bot-friendly method that triggers automatic release of an expired escrow without requiring a signing keypair.

### Changes

- Added 	riggerAutoRelease(id, currentLedger?) to EscrowModule`n- No keypair required - callable by anyone (keeper bot use case)`n- Pre-flight validates escrow exists, not already settled, and expiry ledger reached`n- Calls contract 	rigger_auto_release`n- Added unit tests for all validation paths and success scenarios`n- Ensured no unrelated changes were introduced`n
Closes #228