### PR TITLE
Add EscrowModule.getEscrowAge() to return active ledger count

### DIFF
--- a/src/modules/escrow.ts
+++ b/src/modules/escrow.ts
@@ -14,7 +14,7 @@ import type {
   TransactionResult,
   BatchSettlementResult,
 } from '../types/index';
-import { addressToScVal, bigintToScVal, scValToBigint, stringToScVal } from '../utils/scval';
+import { addressToScVal, bigintToScVal, scValToBigint, scValToNumber, stringToScVal } from '../utils/scval';
 import { buildContractCall, submitTransaction } from '../utils/transaction';
 import { parseSorobanError, VeriTixError, VeriTixErrorCode } from '../utils/errors';
 import { parseEscrowRecord } from '../utils/parsers';
@@ -227,6 +227,56 @@ export class EscrowModule {
 
     const ledger = currentLedger ?? (await this.server.getLatestLedger()).sequence;
     return ledger >= record.expiryLedger;
+  }
+
+  /**
+   * Returns how many ledgers an escrow has been active.
+   * Returns `0` for settled (released or refunded) escrows.
+   *
+   * @param escrowId      - Numeric escrow identifier.
+   * @param currentLedger - Optional current ledger sequence. If not provided, fetches from the server.
+   * @returns The number of ledgers the escrow has been active.
+   * @throws {VeriTixError} With code `ESCROW_NOT_FOUND` if the escrow does not exist.
+   *
+   * @example
+   * ```ts
+   * const age = await client.escrow.getEscrowAge(1n);
+   * console.log('Escrow has been active for', age, 'ledgers');
+   * ```
+   */
+  async getEscrowAge(escrowId: bigint, currentLedger?: number): Promise<number> {
+    const escrow = await this.getEscrow(escrowId);
+    if (!escrow) {
+      throw new VeriTixError(VeriTixErrorCode.EscrowNotFound, 'Escrow not found');
+    }
+
+    if (escrow.released || escrow.refunded) {
+      return 0;
+    }
+
+    const sourceAccount = new Account(DUMMY_PUBLIC_KEY, '0');
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      'get_escrow_age',
+      [bigintToScVal(escrowId, 'u64')],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result ? raw.result.retval : undefined;
+
+    if (!returnValue) {
+      return 0;
+    }
+
+    return scValToNumber(returnValue);
   }
 
   // -------------------------------------------------------------------------

--- a/tests/escrow.test.ts
+++ b/tests/escrow.test.ts
@@ -629,6 +629,51 @@ describe('EscrowModule.isExpired', () => {
   });
 });
 
+describe('EscrowModule.getEscrowAge', () => {
+  it('throws ESCROW_NOT_FOUND when escrow does not exist', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue(null);
+    await expect(client.escrow.getEscrowAge(1n)).rejects.toMatchObject({
+      code: VeriTixErrorCode.EscrowNotFound,
+    });
+  });
+
+  it('returns 0 for released escrow', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: true, refunded: false, expiryLedger: 1_005_000, memos: [],
+    });
+    const age = await client.escrow.getEscrowAge(1n);
+    expect(age).toBe(0);
+  });
+
+  it('returns 0 for refunded escrow', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: true, expiryLedger: 1_005_000, memos: [],
+    });
+    const age = await client.escrow.getEscrowAge(1n);
+    expect(age).toBe(0);
+  });
+
+  it('calls get_escrow_age contract method for active escrow', async () => {
+    const { client, mockServer } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrow').mockResolvedValue({
+      id: 1n, depositor: FAKE_DEPOSITOR, beneficiary: FAKE_ADDRESS,
+      amount: 1_000_000n, released: false, refunded: false, expiryLedger: 1_005_000, memos: [],
+    });
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: { retval: nativeToScVal(500, { type: 'u32' }) },
+    });
+    const age = await client.escrow.getEscrowAge(1n);
+    expect(age).toBe(500);
+    expect(mockServer.simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('EscrowModule.settleEvent', () => {
   const keypair = Keypair.random();
 


### PR DESCRIPTION
## Summary

Implemented getEscrowAge() - returns how many ledgers an escrow has been active.

### Changes

- Added getEscrowAge(escrowId, currentLedger?) to EscrowModule`n- Returns 0 for settled (released or refunded) escrows`n- Calls contract get_escrow_age view for active escrows`n- Added unit tests for not found, settled, and active escrow scenarios`n- Ensured no unrelated changes were introduced`n
Closes #229