### PR TITLE
Add EscrowModule.getEscrowedValueForDepositor() to sum escrowed values

### DIFF
--- a/src/modules/escrow.ts
+++ b/src/modules/escrow.ts
@@ -229,6 +229,42 @@ export class EscrowModule {
     return ledger >= record.expiryLedger;
   }
 
+  /**
+   * Returns the total escrowed value held across all active escrows for a given depositor.
+   *
+   * @param depositor - Stellar account address of the depositor.
+   * @returns The sum of `amount` across all active (unreleased, unrefunded) escrows.
+   * @throws {VeriTixError} With code `INVALID_ADDRESS` if the depositor address is invalid.
+   *
+   * @example
+   * ```ts
+   * const total = await client.escrow.getEscrowedValueForDepositor('GABC…');
+   * console.log('Total escrowed:', total);
+   * ```
+   */
+  async getEscrowedValueForDepositor(depositor: string): Promise<bigint> {
+    try {
+      new Address(depositor);
+    } catch {
+      throw new VeriTixError(VeriTixErrorCode.InvalidAddress, 'EscrowModule.getEscrowedValueForDepositor: invalid depositor address');
+    }
+
+    const escrowIds = await this.getEscrowsByDepositor(depositor);
+
+    if (escrowIds.length === 0) {
+      return 0n;
+    }
+
+    const escrows = await this.getEscrowsBatch(escrowIds);
+
+    return escrows.reduce((sum, escrow) => {
+      if (escrow && !escrow.released && !escrow.refunded) {
+        return sum + escrow.amount;
+      }
+      return sum;
+    }, 0n);
+  }
+
   // -------------------------------------------------------------------------
   // Write operations
   // -------------------------------------------------------------------------

--- a/tests/escrow.test.ts
+++ b/tests/escrow.test.ts
@@ -990,3 +990,58 @@ describe('EscrowModule.createEscrow — pre-flight VeriTixError validation', () 
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// getEscrowedValueForDepositor tests
+// ---------------------------------------------------------------------------
+
+describe('EscrowModule.getEscrowedValueForDepositor', () => {
+  it('throws INVALID_ADDRESS for bad address', async () => {
+    const { client } = makeConnectedClient();
+    await expect(client.escrow.getEscrowedValueForDepositor('not-a-valid-address')).rejects.toMatchObject({
+      code: VeriTixErrorCode.InvalidAddress,
+    });
+  });
+
+  it('returns 0n when depositor has no escrows', async () => {
+    const validAddress = Keypair.random().publicKey();
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrowsByDepositor').mockResolvedValue([]);
+    const total = await client.escrow.getEscrowedValueForDepositor(validAddress);
+    expect(total).toBe(0n);
+  });
+
+  it('returns 0n when all escrows are settled', async () => {
+    const validAddress = Keypair.random().publicKey();
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrowsByDepositor').mockResolvedValue([1n, 2n]);
+    jest.spyOn(client.escrow, 'getEscrowsBatch').mockResolvedValue([
+      { id: 1n, depositor: validAddress, beneficiary: FAKE_ADDRESS, amount: 1_000_000n, released: true, refunded: false, expiryLedger: 1_000_000, memos: [] },
+      { id: 2n, depositor: validAddress, beneficiary: FAKE_ADDRESS, amount: 2_000_000n, released: false, refunded: true, expiryLedger: 1_000_000, memos: [] },
+    ]);
+    const total = await client.escrow.getEscrowedValueForDepositor(validAddress);
+    expect(total).toBe(0n);
+  });
+
+  it('sums amounts for active escrows only', async () => {
+    const validAddress = Keypair.random().publicKey();
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrowsByDepositor').mockResolvedValue([1n, 2n, 3n]);
+    jest.spyOn(client.escrow, 'getEscrowsBatch').mockResolvedValue([
+      { id: 1n, depositor: validAddress, beneficiary: FAKE_ADDRESS, amount: 1_000_000n, released: false, refunded: false, expiryLedger: 1_000_000, memos: [] },
+      { id: 2n, depositor: validAddress, beneficiary: FAKE_ADDRESS, amount: 2_000_000n, released: true, refunded: false, expiryLedger: 1_000_000, memos: [] },
+      { id: 3n, depositor: validAddress, beneficiary: FAKE_ADDRESS, amount: 3_000_000n, released: false, refunded: false, expiryLedger: 1_000_000, memos: [] },
+    ]);
+    const total = await client.escrow.getEscrowedValueForDepositor(validAddress);
+    expect(total).toBe(4_000_000n);
+  });
+
+  it('returns 0n when batch returns all nulls', async () => {
+    const validAddress = Keypair.random().publicKey();
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.escrow, 'getEscrowsByDepositor').mockResolvedValue([1n, 2n]);
+    jest.spyOn(client.escrow, 'getEscrowsBatch').mockResolvedValue([null, null]);
+    const total = await client.escrow.getEscrowedValueForDepositor(validAddress);
+    expect(total).toBe(0n);
+  });
+});


### PR DESCRIPTION
## Summary

Implemented getEscrowedValueForDepositor() - returns total escrowed value across all active escrows for a given depositor.

### Changes

- Added getEscrowedValueForDepositor(depositor) to EscrowModule - Returns sum of mount across all active (unreleased, unrefunded) escrows - Returns n for no escrows or all settled - Validates depositor address, throws INVALID_ADDRESS on bad input - Added 5 unit tests covering invalid address, no escrows, all settled, mixed active/settled, and null batch results
- Also fixed several pre-existing TypeScript compilation errors across the codebase

Closes #230