### PR TITLE
feat(#285): add VeriTixClient.batchRead() — parallel typed read operations

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -34,7 +34,6 @@ import type {
   ContractMetadata,
   TransactionResult,
   StellarNetwork,
-  WatchOptions,
   EscrowRecord,
 } from './types/index';
 import { buildContractCall, simulateTransaction } from './utils/transaction';
@@ -478,6 +477,38 @@ export class VeriTixClient extends EventEmitter {
       contractId: this.config.contractId,
       network: this.config.network,
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // batchRead  (#285)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Executes multiple read operations in parallel and returns their results
+   * as a strongly-typed tuple.
+   *
+   * All operations run concurrently via `Promise.all`.  If **any** operation
+   * throws, the entire batch rejects with the first error.
+   *
+   * @typeParam T - Tuple type inferred from the provided operation callbacks.
+   * @param operations - A tuple of zero-argument async callbacks, each
+   *   returning a value of its corresponding type.
+   * @returns A `Promise` that resolves to a tuple where each element is the
+   *   resolved value of the matching operation.
+   *
+   * @example
+   * ```ts
+   * const [balance, escrow, tokenName] = await client.batchRead([
+   *   () => client.token.balance('GABC…'),
+   *   () => client.escrow.getEscrow(1n),
+   *   () => client.token.name(),
+   * ] as const);
+   * ```
+   */
+  async batchRead<T extends readonly unknown[]>(
+    operations: readonly [...{ (): Promise<T[number]> }[]],
+  ): Promise<T> {
+    return Promise.all(operations.map((op) => op())) as unknown as Promise<T>;
   }
 
   // -------------------------------------------------------------------------

--- a/src/modules/batch.ts
+++ b/src/modules/batch.ts
@@ -250,18 +250,6 @@ export class BatchModule {
     return this.writeCall('transfer_batch_with_memo', [entries]);
   }
 
-  async freezeBatch(_addresses: string[]): Promise<TransactionResult> {
-    throw new Error('BatchModule.freezeBatch: not implemented');
-  }
-
-  async freezeBatch(_addresses: string[]): Promise<TransactionResult> {
-    throw new Error('BatchModule.freezeBatch: not implemented');
-  }
-
-  async clawbackBatch(_targets: BatchClawbackTarget[]): Promise<TransactionResult> {
-    throw new Error('BatchModule.clawbackBatch: not implemented');
-  }
-
   /**
    * Freezes multiple accounts in a single contract invocation.
    * Caller must be the contract admin.

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -87,14 +87,10 @@ export enum VeriTixErrorCode {
   BatchTooLarge = 'BATCH_TOO_LARGE',
   /** Client has no Keypair — write operations are not available */
   ReadOnlyClient = 'READ_ONLY_CLIENT',
-  /** Supplied address is not a valid Stellar Ed25519 public key */
-  InvalidAddress = 'INVALID_ADDRESS',
-  /** watchTransaction() timed out waiting for confirmation */
+  /** watchTransaction() or watchEscrow() timed out waiting for confirmation */
   WatchTimeout = 'WATCH_TIMEOUT',
   /** Transaction was rejected by the network */
   TransactionFailed = 'TRANSACTION_FAILED',
-  /** watchEscrow timed out before the escrow settled */
-  WatchTimeout = 'WATCH_TIMEOUT',
 }
 
 // ---------------------------------------------------------------------------
@@ -260,16 +256,14 @@ function buildMessage(code: VeriTixErrorCode, rawStr: string): string {
     [VeriTixErrorCode.Unauthorized]:                'Caller is not authorized to perform this operation.',
     [VeriTixErrorCode.InvalidAmount]:               'Amount must be greater than zero.',
     [VeriTixErrorCode.InvalidExpiryLedger]:         'Expiry ledger must be greater than the current ledger.',
-    [VeriTixErrorCode.InvalidAddress]:              'Beneficiary is not a valid Stellar account address.',
+    [VeriTixErrorCode.InvalidAddress]:              'Supplied address is not a valid Stellar Ed25519 public key.',
     [VeriTixErrorCode.InvalidBeneficiary]:          'Beneficiary must not be the same as the depositor.',
     [VeriTixErrorCode.Unknown]:                     `Unrecognised contract error: ${rawStr}`,
     [VeriTixErrorCode.ConnectionFailed]:            'Failed to connect to the Soroban RPC endpoint.',
     [VeriTixErrorCode.BatchTooLarge]:               'Batch request exceeded maximum allowed size.',
     [VeriTixErrorCode.ReadOnlyClient]:              'This client is read-only. Provide a Keypair to enable write operations.',
-    [VeriTixErrorCode.InvalidAddress]:              'Supplied address is not a valid Stellar Ed25519 public key.',
-    [VeriTixErrorCode.WatchTimeout]:                'watchTransaction() timed out before the transaction was confirmed.',
+    [VeriTixErrorCode.WatchTimeout]:                'watchEscrow or watchTransaction timed out before the operation was confirmed.',
     [VeriTixErrorCode.TransactionFailed]:           'Transaction was rejected by the Stellar network.',
-    [VeriTixErrorCode.WatchTimeout]:                'watchEscrow timed out before the escrow settled.',
   };
   return messages[code];
 }

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -185,6 +185,8 @@ export function ledgerToApproxDate(ledger: number, currentLedger: number, curren
   const now = currentDate ?? new Date();
   const secondsDiff = (ledger - currentLedger) * LEDGER_CLOSE_SECONDS;
   return new Date(now.getTime() + secondsDiff * 1000);
+}
+
 // Address validation
 // ---------------------------------------------------------------------------
 

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -148,8 +148,11 @@ export async function estimateFee(
   method: string,
   args: xdr.ScVal[],
 ): Promise<FeeEstimate> {
-  // Use a throwaway keypair — simulation does not require a funded account
-  const result = await server.simulateTransaction(tx);
+  // Use a throwaway source account — simulation does not require a funded account
+  const sourceAccount = new Account(
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    '0',
+  );
 
   const tx = await buildContractCall(
     server,

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -224,3 +224,109 @@ describe('VeriTixClient', () => {
     });
   });
 });
+
+// -------------------------------------------------------------------------
+// batchRead()  (#285)
+// -------------------------------------------------------------------------
+
+describe('batchRead() (#285)', () => {
+  it('executes all operations in parallel and returns a typed tuple', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.token, 'name').mockResolvedValue('VeriTix Token');
+    jest.spyOn(client.token, 'symbol').mockResolvedValue('VTX');
+    jest.spyOn(client.token, 'decimals').mockResolvedValue(7);
+
+    const [name, symbol, decimal] = await client.batchRead<[string, string, number]>([
+      () => client.token.name(),
+      () => client.token.symbol(),
+      () => client.token.decimals(),
+    ]);
+
+    expect(name).toBe('VeriTix Token');
+    expect(symbol).toBe('VTX');
+    expect(decimal).toBe(7);
+  });
+
+  it('rejects with the first error if any operation throws', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.token, 'name').mockResolvedValue('ok');
+    jest.spyOn(client.token, 'symbol').mockRejectedValue(
+      new VeriTixError(VeriTixErrorCode.Unknown, 'symbol RPC failed'),
+    );
+
+    await expect(
+      client.batchRead([
+        () => client.token.name(),
+        () => client.token.symbol(),
+      ]),
+    ).rejects.toMatchObject({ code: VeriTixErrorCode.Unknown });
+  });
+
+  it('returns an empty array for an empty operations list', async () => {
+    const { client } = makeConnectedClient();
+    const result = await client.batchRead([]);
+    expect(result).toEqual([]);
+  });
+
+  it('runs operations concurrently — slower op resolves after faster op', async () => {
+    const { client } = makeConnectedClient();
+    const order: string[] = [];
+
+    const op1 = jest.fn().mockImplementation(async () => {
+      await new Promise<void>((r) => setTimeout(r, 20));
+      order.push('op1');
+      return 'a';
+    });
+    const op2 = jest.fn().mockImplementation(async () => {
+      order.push('op2');
+      return 'b';
+    });
+
+    const [a, b] = await client.batchRead<[string, string]>([op1, op2]);
+
+    expect(a).toBe('a');
+    expect(b).toBe('b');
+    // op2 resolved first because op1 has a delay
+    expect(order[0]).toBe('op2');
+    expect(order[1]).toBe('op1');
+  });
+
+  it('works with a single operation', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.token, 'name').mockResolvedValue('Solo');
+
+    const [name] = await client.batchRead<[string]>([() => client.token.name()]);
+    expect(name).toBe('Solo');
+  });
+
+  it('handles mixed return types — string, number, bigint', async () => {
+    const { client } = makeConnectedClient();
+    jest.spyOn(client.token, 'name').mockResolvedValue('VeriTix');
+    jest.spyOn(client.token, 'decimals').mockResolvedValue(7);
+    jest.spyOn(client.token, 'totalSupply').mockResolvedValue(999n);
+
+    const [name, decimals, supply] = await client.batchRead<[string, number, bigint]>([
+      () => client.token.name(),
+      () => client.token.decimals(),
+      () => client.token.totalSupply(),
+    ]);
+
+    expect(name).toBe('VeriTix');
+    expect(decimals).toBe(7);
+    expect(supply).toBe(999n);
+  });
+
+  it('calls each operation exactly once', async () => {
+    const { client } = makeConnectedClient();
+    const nameMock = jest.spyOn(client.token, 'name').mockResolvedValue('once');
+    const symbolMock = jest.spyOn(client.token, 'symbol').mockResolvedValue('O');
+
+    await client.batchRead([
+      () => client.token.name(),
+      () => client.token.symbol(),
+    ]);
+
+    expect(nameMock).toHaveBeenCalledTimes(1);
+    expect(symbolMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `VeriTixClient.batchRead()` — a typed method that executes multiple read operations concurrently and returns their results as a strongly-typed tuple. Useful for frontends and dashboards that need several read values without losing type safety.

## Changes

### New
- `batchRead<T extends readonly unknown[]>(operations): Promise<T>` on `VeriTixClient`
  - Executes all callbacks concurrently via `Promise.all`
  - Rejects with the first error if any operation throws
  - Return type is inferred from the provided callbacks
  - JSDoc with `@example` showing fetching balance + escrow + token info

### Pre-existing fixes (required for compilation)
- Duplicate `VeriTixErrorCode` enum entries removed from `errors.ts`
- `estimateFee` referenced `tx`/`sourceAccount` before declaration — fixed
- `ledgerToApproxDate` missing closing brace in `network.ts` — fixed
- Duplicate `freezeBatch` implementations in `batch.ts` — fixed

## Tests

Added 7 tests in `tests/client.test.ts`:
- Executes all operations and returns a typed tuple
- Rejects with the first error if any operation throws
- Returns empty array for empty operations list
- Runs operations concurrently (slower op resolves after faster op)
- Works with a single operation
- Handles mixed return types (string, number, bigint)
- Calls each operation exactly once

Closes #285