### PR TITLE
Add DisputeModule.expireDispute() to force-expire expired disputes

### DIFF
--- a/src/modules/dispute.ts
+++ b/src/modules/dispute.ts
@@ -468,4 +468,71 @@ export class DisputeModule {
       returnValue,
     };
   }
+
+  /**
+   * Force-expires an expired dispute. Must be called by the contract admin.
+   *
+   * @param disputeId - The dispute ID to expire.
+   * @returns A {@link TransactionResult} on success.
+   * @throws {Error} If no signing keypair is available.
+   * @throws {VeriTixError} With code `DISPUTE_NOT_FOUND` if dispute does not exist.
+   * @throws {VeriTixError} With code `DISPUTE_ALREADY_RESOLVED` if already resolved.
+   *
+   * @example
+   * ```ts
+   * await client.dispute.expireDispute(3n);
+   * ```
+   */
+  async expireDispute(disputeId: bigint): Promise<TransactionResult> {
+    if (!this.keypair) {
+      throw new Error('DisputeModule.expireDispute: signing keypair required');
+    }
+
+    const dispute = await this.getDispute(disputeId);
+    if (!dispute) {
+      throw new VeriTixError(
+        VeriTixErrorCode.DisputeNotFound,
+        'Dispute not found',
+      );
+    }
+
+    if (dispute.status !== DisputeStatus.Open) {
+      throw new VeriTixError(
+        VeriTixErrorCode.DisputeAlreadyResolved,
+        'Dispute already resolved',
+      );
+    }
+
+    const admin = this.keypair.publicKey();
+
+    const tx = await buildContractCall(
+      this.server,
+      new Account(admin, '0'),
+      this.config.contractId,
+      'expire_dispute',
+      [
+        addressToScVal(admin),
+        bigintToScVal(disputeId, 'u64'),
+      ],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result
+        ? raw.result.retval
+        : undefined;
+
+    const assembled = SorobanRpc.assembleTransaction(tx, raw).build();
+    const result = await submitTransaction(this.server, assembled, this.keypair);
+
+    return {
+      ...result,
+      returnValue,
+    };
+  }
 }

--- a/tests/dispute.test.ts
+++ b/tests/dispute.test.ts
@@ -386,3 +386,43 @@ describe('DisputeModule', () => {
   });
 });
 
+describe('DisputeModule.expireDispute', () => {
+  it('throws when no signing keypair', async () => {
+    const client = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT_ID));
+    await expect(client.dispute.expireDispute(1n)).rejects.toThrow('signing keypair required');
+  });
+
+  it('throws DISPUTE_NOT_FOUND when dispute does not exist', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: { retval: undefined },
+    });
+    await expect(client.dispute.expireDispute(999n)).rejects.toMatchObject({
+      code: VeriTixErrorCode.DisputeNotFound,
+    });
+  });
+
+  it('throws DISPUTE_ALREADY_RESOLVED when dispute is not open', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    const disputeId = 1n;
+    const mockRecord = xdr.ScVal.scvMap([
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('id'), val: xdr.ScVal.scvU64(xdr.Uint64.fromString('1')) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('escrow_id'), val: xdr.ScVal.scvU64(xdr.Uint64.fromString('100')) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('claimant'), val: xdr.ScVal.scvString(Keypair.random().publicKey()) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('resolver'), val: xdr.ScVal.scvString(Keypair.random().publicKey()) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('status'), val: xdr.ScVal.scvSymbol('ResolvedForBeneficiary') }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('opened_at'), val: xdr.ScVal.scvU64(xdr.Uint64.fromString('500')) }),
+    ]);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: { retval: mockRecord },
+    });
+    await expect(client.dispute.expireDispute(disputeId)).rejects.toMatchObject({
+      code: VeriTixErrorCode.DisputeAlreadyResolved,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary

Implemented expireDispute() - admin-only method to force-expire an open dispute.

### Changes
- Added expireDispute(disputeId) to DisputeModule - Requires signing keypair - Validates dispute exists and is still open - Calls contract expire_dispute method - Added 3 unit tests

Closes #234