### PR TITLE
Add DisputeModule.appealDispute() to appeal resolved disputes

### DIFF
--- a/src/modules/dispute.ts
+++ b/src/modules/dispute.ts
@@ -468,4 +468,71 @@ export class DisputeModule {
       returnValue,
     };
   }
+
+  /**
+   * Appeals a resolved dispute. Must be called by the original claimant.
+   *
+   * @param disputeId - The dispute ID to appeal.
+   * @returns A {@link TransactionResult} on success.
+   * @throws {Error} If no signing keypair is available.
+   * @throws {VeriTixError} With code `DISPUTE_NOT_FOUND` if dispute does not exist.
+   * @throws {VeriTixError} With code `DISPUTE_INVALID_STATE` if dispute is still open.
+   *
+   * @example
+   * ```ts
+   * await client.dispute.appealDispute(3n);
+   * ```
+   */
+  async appealDispute(disputeId: bigint): Promise<TransactionResult> {
+    if (!this.keypair) {
+      throw new Error('DisputeModule.appealDispute: signing keypair required');
+    }
+
+    const dispute = await this.getDispute(disputeId);
+    if (!dispute) {
+      throw new VeriTixError(
+        VeriTixErrorCode.DisputeNotFound,
+        'Dispute not found',
+      );
+    }
+
+    if (dispute.status === DisputeStatus.Open) {
+      throw new VeriTixError(
+        VeriTixErrorCode.InvalidAmount,
+        'DisputeModule.appealDispute: dispute is still open, cannot appeal',
+      );
+    }
+
+    const claimant = this.keypair.publicKey();
+
+    const tx = await buildContractCall(
+      this.server,
+      new Account(claimant, '0'),
+      this.config.contractId,
+      'appeal_dispute',
+      [
+        addressToScVal(claimant),
+        bigintToScVal(disputeId, 'u64'),
+      ],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result
+        ? raw.result.retval
+        : undefined;
+
+    const assembled = SorobanRpc.assembleTransaction(tx, raw).build();
+    const result = await submitTransaction(this.server, assembled, this.keypair);
+
+    return {
+      ...result,
+      returnValue,
+    };
+  }
 }

--- a/tests/dispute.test.ts
+++ b/tests/dispute.test.ts
@@ -386,3 +386,40 @@ describe('DisputeModule', () => {
   });
 });
 
+describe('DisputeModule.appealDispute', () => {
+  it('throws when no signing keypair', async () => {
+    const client = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT_ID));
+    await expect(client.dispute.appealDispute(1n)).rejects.toThrow('signing keypair required');
+  });
+
+  it('throws DISPUTE_NOT_FOUND when dispute does not exist', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: { retval: undefined },
+    });
+    await expect(client.dispute.appealDispute(999n)).rejects.toMatchObject({
+      code: VeriTixErrorCode.DisputeNotFound,
+    });
+  });
+
+  it('throws when dispute is still open', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    const mockRecord = xdr.ScVal.scvMap([
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('id'), val: xdr.ScVal.scvU64(xdr.Uint64.fromString('1')) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('escrow_id'), val: xdr.ScVal.scvU64(xdr.Uint64.fromString('100')) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('claimant'), val: xdr.ScVal.scvString(keypair.publicKey()) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('resolver'), val: xdr.ScVal.scvString(Keypair.random().publicKey()) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('status'), val: xdr.ScVal.scvSymbol('Open') }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('opened_at'), val: xdr.ScVal.scvU64(xdr.Uint64.fromString('500')) }),
+    ]);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: { retval: mockRecord },
+    });
+    await expect(client.dispute.appealDispute(1n)).rejects.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary

Implemented ppealDispute() - allows the original claimant to appeal a resolved dispute.

### Changes
- Added ppealDispute(disputeId) to DisputeModule - Requires signing keypair - Validates dispute exists and is resolved - Calls contract appeal_dispute method - Added 3 unit tests

Closes #236