### PR TITLE
Add DisputeModule.getDisputeStats() to return dispute statistics

### DIFF
--- a/src/modules/dispute.ts
+++ b/src/modules/dispute.ts
@@ -13,7 +13,7 @@ import {
   NetworkConfig,
   TransactionResult,
 } from '../types/index';
-import { addressToScVal, bigintToScVal, boolToScVal, scValToBoolean } from '../utils/scval';
+import { addressToScVal, bigintToScVal, boolToScVal, scValToBigint, scValToBoolean, scValToNumber } from '../utils/scval';
 import { buildContractCall, submitTransaction } from '../utils/transaction';
 import { parseSorobanError, VeriTixError, VeriTixErrorCode } from '../utils/errors';
 import { parseDisputeRecord } from '../utils/parsers';
@@ -246,6 +246,75 @@ export class DisputeModule {
       if (typeof id === 'number') return BigInt(id);
       throw new Error(`Unexpected type in disputes array: ${typeof id}`);
     });
+  }
+
+  /**
+   * Returns aggregate dispute statistics.
+   *
+   * @returns Object with `total`, `open`, `resolvedForBeneficiary`, `resolvedForDepositor`, and `expired`.
+   * @throws {VeriTixError} If the contract returns no data or an unexpected format.
+   *
+   * @example
+   * ```ts
+   * const stats = await client.dispute.getDisputeStats();
+   * console.log('Open disputes:', stats.open);
+   * ```
+   */
+  async getDisputeStats(): Promise<{
+    total: number;
+    open: number;
+    resolvedForBeneficiary: number;
+    resolvedForDepositor: number;
+    expired: number;
+  }> {
+    const sourceAccount = new Account(DUMMY_PUBLIC_KEY, '0');
+
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      'get_dispute_stats',
+      [],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result ? raw.result.retval : undefined;
+
+    if (!returnValue || returnValue.switch() === xdr.ScValType.scvVoid()) {
+      throw new VeriTixError(VeriTixErrorCode.Unknown, 'DisputeModule.getDisputeStats: no data returned');
+    }
+
+    if (returnValue.switch() !== xdr.ScValType.scvMap()) {
+      throw new VeriTixError(VeriTixErrorCode.Unknown, 'DisputeModule.getDisputeStats: expected ScMap result');
+    }
+
+    const map = returnValue.map() ?? [];
+    const get = (key: string): xdr.ScVal | undefined =>
+      map.find((e) => e.key().sym() === key)?.val();
+
+    const totalVal = get('total');
+    const openVal = get('open');
+    const resolvedForBeneficiaryVal = get('resolved_for_beneficiary');
+    const resolvedForDepositorVal = get('resolved_for_depositor');
+    const expiredVal = get('expired');
+
+    if (!totalVal || !openVal || !resolvedForBeneficiaryVal || !resolvedForDepositorVal || !expiredVal) {
+      throw new VeriTixError(VeriTixErrorCode.Unknown, 'DisputeModule.getDisputeStats: incomplete stats map');
+    }
+
+    return {
+      total: scValToNumber(totalVal),
+      open: scValToNumber(openVal),
+      resolvedForBeneficiary: scValToNumber(resolvedForBeneficiaryVal),
+      resolvedForDepositor: scValToNumber(resolvedForDepositorVal),
+      expired: scValToNumber(expiredVal),
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/tests/dispute.test.ts
+++ b/tests/dispute.test.ts
@@ -386,3 +386,46 @@ describe('DisputeModule', () => {
   });
 });
 
+describe('DisputeModule.getDisputeStats', () => {
+  it('throws when simulation returns error', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({ status: 'ERROR', error: 'contract panic' });
+    await expect(client.dispute.getDisputeStats()).rejects.toThrow();
+  });
+
+  it('throws when simulation returns void', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: { retval: xdr.ScVal.scvVoid() },
+    });
+    await expect(client.dispute.getDisputeStats()).rejects.toMatchObject({
+      code: VeriTixErrorCode.Unknown,
+    });
+  });
+
+  it('parses a valid dispute stats map', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    const mapVal = xdr.ScVal.scvMap([
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('total'), val: xdr.ScVal.scvU32(100) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('open'), val: xdr.ScVal.scvU32(15) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('resolved_for_beneficiary'), val: xdr.ScVal.scvU32(40) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('resolved_for_depositor'), val: xdr.ScVal.scvU32(30) }),
+      new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('expired'), val: xdr.ScVal.scvU32(15) }),
+    ]);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: { retval: mapVal },
+    });
+    const stats = await client.dispute.getDisputeStats();
+    expect(stats.total).toBe(100);
+    expect(stats.open).toBe(15);
+    expect(stats.resolvedForBeneficiary).toBe(40);
+    expect(stats.resolvedForDepositor).toBe(30);
+    expect(stats.expired).toBe(15);
+  });
+});
+


### PR DESCRIPTION
## Summary

Implemented getDisputeStats() - returns total, open, resolvedForBeneficiary, resolvedForDepositor, and expired.

### Changes
- Added getDisputeStats() to DisputeModule - Calls contract get_dispute_stats view - Parses ScMap result into typed object - Added 3 unit tests

Closes #237