### PR TITLE
Add DisputeModule.getDisputesByClaimant() to list disputes by claimant

### DIFF
--- a/src/modules/dispute.ts
+++ b/src/modules/dispute.ts
@@ -248,6 +248,56 @@ export class DisputeModule {
     });
   }
 
+  /**
+   * Fetches all dispute IDs raised by a specific claimant.
+   *
+   * @param claimant - Stellar account address of the claimant.
+   * @returns Array of dispute IDs for the claimant.
+   *
+   * @example
+   * ```ts
+   * const disputes = await client.dispute.getDisputesByClaimant('GABC…');
+   * console.log('My disputes:', disputes);
+   * ```
+   */
+  async getDisputesByClaimant(claimant: string): Promise<bigint[]> {
+    const sourceAccount = new Account(DUMMY_PUBLIC_KEY, '0');
+
+    const tx = await buildContractCall(
+      this.server,
+      sourceAccount,
+      this.config.contractId,
+      'get_disputes_by_claimant',
+      [addressToScVal(claimant)],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result
+        ? raw.result.retval
+        : undefined;
+
+    if (!returnValue) {
+      return [];
+    }
+
+    const native = scValToNative(returnValue);
+    if (!Array.isArray(native)) {
+      throw new Error('Expected array from get_disputes_by_claimant');
+    }
+
+    return native.map((id) => {
+      if (typeof id === 'bigint') return id;
+      if (typeof id === 'number') return BigInt(id);
+      throw new Error(`Unexpected type in disputes array: ${typeof id}`);
+    });
+  }
+
   // -------------------------------------------------------------------------
   // Write operations
   // -------------------------------------------------------------------------

--- a/tests/dispute.test.ts
+++ b/tests/dispute.test.ts
@@ -386,3 +386,44 @@ describe('DisputeModule', () => {
   });
 });
 
+describe('DisputeModule.getDisputesByClaimant', () => {
+  it('returns dispute IDs for a claimant', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    const claimant = Keypair.random().publicKey();
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: {
+        retval: xdr.ScVal.scvVec([
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('1')),
+          xdr.ScVal.scvU64(xdr.Uint64.fromString('5')),
+        ]),
+      },
+    });
+    const disputes = await client.dispute.getDisputesByClaimant(claimant);
+    expect(disputes).toEqual([1n, 5n]);
+  });
+
+  it('returns empty array when no disputes', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    const claimant = Keypair.random().publicKey();
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'SUCCESS',
+      result: { retval: undefined },
+    });
+    const disputes = await client.dispute.getDisputesByClaimant(claimant);
+    expect(disputes).toEqual([]);
+  });
+
+  it('throws error on simulation failure', async () => {
+    const keypair = Keypair.random();
+    const { client, mockServer } = makeConnectedClient(keypair);
+    mockServer.simulateTransaction.mockResolvedValue({
+      status: 'ERROR',
+      error: 'contract panic',
+    });
+    await expect(client.dispute.getDisputesByClaimant(Keypair.random().publicKey())).rejects.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary

Implemented getDisputesByClaimant() - returns all dispute IDs raised by a specific claimant.

### Changes
- Added getDisputesByClaimant(claimant) to DisputeModule - Calls contract get_disputes_by_claimant view - Returns bigint[] of dispute IDs - Added 3 unit tests

Closes #238