### PR TITLE
Add SplitterModule.replaceRecipient() to replace compromised recipients

### DIFF
--- a/src/modules/splitter.ts
+++ b/src/modules/splitter.ts
@@ -3,8 +3,8 @@
  * Payment splitter operations exposed by the VeriTix Soroban contract.
  */
 
-import { SorobanRpc, Keypair, Account } from '@stellar/stellar-sdk';
-import { addressToScVal, scValToBigint } from '../utils/scval';
+import { SorobanRpc, Keypair, Account, xdr } from '@stellar/stellar-sdk';
+import { addressToScVal, scValToBigint, scValToNumber, stringToScVal } from '../utils/scval';
 import { buildContractCall, simulateTransaction, submitTransaction } from '../utils/transaction';
 import { parseSorobanError, VeriTixError, VeriTixErrorCode } from '../utils/errors';
 import { DUMMY_PUBLIC_KEY } from '../utils/network';
@@ -199,6 +199,62 @@ export class SplitterModule {
       { address: platform, shareBps: 10_000 - totalBps },
     ];
     return this.createSplit({ recipients, totalAmount });
+  }
+
+  /**
+   * Replaces a compromised recipient address in an existing split.
+   * Must be called by the split sender.
+   *
+   * @param splitId - The split ID containing the recipient to replace.
+   * @param oldRecipient - The current recipient address to replace.
+   * @param newRecipient - The new recipient address.
+   * @returns A {@link TransactionResult} on success.
+   * @throws {Error} If no signing keypair is available.
+   *
+   * @example
+   * ```ts
+   * await client.splitter.replaceRecipient(2n, 'GOLD…', 'NEW…');
+   * ```
+   */
+  async replaceRecipient(
+    splitId: bigint,
+    oldRecipient: string,
+    newRecipient: string,
+  ): Promise<TransactionResult> {
+    if (!this.keypair) {
+      throw new VeriTixError(VeriTixErrorCode.ReadOnlyClient, 'SplitterModule.replaceRecipient: signing keypair required');
+    }
+
+    const sender = this.keypair.publicKey();
+
+    const tx = await buildContractCall(
+      this.server,
+      new Account(sender, '0'),
+      this.config.contractId,
+      'replace_recipient',
+      [
+        bigintToScVal(splitId, 'u64'),
+        addressToScVal(oldRecipient),
+        addressToScVal(newRecipient),
+      ],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result ? raw.result.retval : undefined;
+
+    const assembled = SorobanRpc.assembleTransaction(tx, raw).build();
+    const result = await submitTransaction(this.server, assembled, this.keypair);
+
+    return {
+      ...result,
+      returnValue,
+    };
   }
 
   /**

--- a/tests/splitter.test.ts
+++ b/tests/splitter.test.ts
@@ -1,6 +1,6 @@
 import { VeriTixClient } from '../src/client';
 import { getTestnetConfig } from '../src/utils/network';
-import { Keypair } from '@stellar/stellar-sdk';
+import { Keypair, xdr } from '@stellar/stellar-sdk';
 import { VeriTixError, VeriTixErrorCode } from '../src/utils/errors';
 
 const FAKE_CONTRACT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
@@ -114,5 +114,12 @@ describe('SplitterModule.createRevenueSplit (validation)', () => {
         totalAmount: 1_000_000n,
       })
     ).rejects.toMatchObject({ code: VeriTixErrorCode.SplitInvalidShares });
+  });
+});
+
+describe('SplitterModule.replaceRecipient', () => {
+  it('throws when no signing keypair', async () => {
+    const client = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT));
+    await expect(client.splitter.replaceRecipient(1n, 'GOLD', 'NEW')).rejects.toThrow('signing keypair required');
   });
 });


### PR DESCRIPTION
## Summary

Implemented eplaceRecipient() - replaces a compromised recipient address in an existing split.

### Changes
- Added eplaceRecipient(splitId, oldRecipient, newRecipient) to SplitterModule - Requires signing keypair (sender-only) - Calls contract replace_recipient method - Added 1 unit test

Closes #241