### PR TITLE
Add RecurringModule.amendRecurring() to update amount/interval

### DIFF
--- a/src/modules/recurring.ts
+++ b/src/modules/recurring.ts
@@ -9,8 +9,8 @@
 import { SorobanRpc, Keypair, Account, xdr } from '@stellar/stellar-sdk';
 import type { NetworkConfig, RecurringRecord, RecurringExecutionEntry, TransactionResult } from '../types/index';
 import { bigintToScVal } from '../utils/scval';
-import { buildContractCall } from '../utils/transaction';
-import { parseSorobanError } from '../utils/errors';
+import { buildContractCall, submitTransaction } from '../utils/transaction';
+import { parseSorobanError, VeriTixError, VeriTixErrorCode } from '../utils/errors';
 import { parseRecurringExecutionEntry } from '../utils/parsers';
 import { DUMMY_PUBLIC_KEY } from '../utils/network';
 
@@ -114,6 +114,54 @@ export class RecurringModule {
   async cancel(_id: bigint): Promise<TransactionResult> {
     // TODO: implement
     throw new Error('RecurringModule.cancel: not implemented');
+  }
+
+  /**
+   * Updates the amount and/or interval of an existing recurring payment.
+   * Must be called by the payer.
+   *
+   * @param id - Numeric recurring-payment identifier.
+   * @param amount - New amount per interval (in stroops). Pass `undefined` to keep current.
+   * @param interval - New charge interval in ledgers. Pass `undefined` to keep current.
+   * @returns A {@link TransactionResult} on success.
+   * @throws {Error} If no signing keypair is available.
+   */
+  async amendRecurring(
+    _id: bigint,
+    _amount?: bigint,
+    _interval?: number,
+  ): Promise<TransactionResult> {
+    if (!this.keypair) {
+      throw new VeriTixError(VeriTixErrorCode.ReadOnlyClient, 'RecurringModule.amendRecurring: signing keypair required');
+    }
+
+    const payer = this.keypair.publicKey();
+
+    const tx = await buildContractCall(
+      this.server,
+      new Account(payer, '0'),
+      this.config.contractId,
+      'amend_recurring',
+      [
+        bigintToScVal(_id, 'u64'),
+        bigintToScVal(_amount ?? 0n, 'i128'),
+        xdr.ScVal.scvU32(_interval ?? 0),
+      ],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result ? raw.result.retval : undefined;
+
+    const assembled = SorobanRpc.assembleTransaction(tx, raw).build();
+    const result = await submitTransaction(this.server, assembled, this.keypair);
+
+    return { ...result, returnValue };
   }
 
   // -------------------------------------------------------------------------

--- a/tests/recurring.test.ts
+++ b/tests/recurring.test.ts
@@ -5,6 +5,8 @@
 import { VeriTixClient } from '../src/client';
 import { getTestnetConfig } from '../src/utils/network';
 import { RecurringModule } from '../src/modules/recurring';
+import { Keypair } from '@stellar/stellar-sdk';
+import { VeriTixErrorCode } from '../src/utils/errors';
 
 const FAKE_CONTRACT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
 const FAKE_PAYER    = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
@@ -106,6 +108,33 @@ describe('RecurringModule', () => {
       expect(result.executed).toEqual([20n]);
       expect(result.skipped).toEqual([21n]);
       expect(result.failed).toEqual([]);
+    });
+  });
+
+  describe('amendRecurring()', () => {
+    it('throws ReadOnlyClient when no keypair', async () => {
+      await expect(recurring.amendRecurring(1n, 100n, 100)).rejects.toThrow('signing keypair required');
+    });
+
+    it('returns tx result on success', async () => {
+      const kp = Keypair.random();
+      const c = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT), kp);
+      const mockServer = { simulateTransaction: jest.fn(), sendTransaction: jest.fn(), getTransaction: jest.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c as any).server = mockServer;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c as any).connected = true;
+
+      mockServer.simulateTransaction.mockResolvedValue({
+        status: 'SUCCESS',
+        result: { retval: undefined },
+      });
+      mockServer.sendTransaction.mockResolvedValue({ hash: 'amend-hash', status: 'PENDING' });
+      mockServer.getTransaction.mockResolvedValue({ status: 'SUCCESS', successful: true, ledger: 50 });
+
+      const result = await c.recurring.amendRecurring(2n, 500n, 3600);
+      expect(result.successful).toBe(true);
+      expect(result.hash).toBe('amend-hash');
     });
   });
 });


### PR DESCRIPTION
## Summary

Implemented mendRecurring() - allows payer to update the amount and/or interval of an existing recurring payment.

### Changes
- Added mendRecurring(id, amount?, interval?) to RecurringModule - Requires signing keypair (payer-only) - Calls contract amend_recurring method - Added 2 unit tests

Closes #243