### PR TITLE
Add RecurringModule.transferPayer() to reassign payer

### DIFF
--- a/src/modules/recurring.ts
+++ b/src/modules/recurring.ts
@@ -8,9 +8,9 @@
 
 import { SorobanRpc, Keypair, Account, xdr } from '@stellar/stellar-sdk';
 import type { NetworkConfig, RecurringRecord, RecurringExecutionEntry, TransactionResult } from '../types/index';
-import { bigintToScVal } from '../utils/scval';
-import { buildContractCall } from '../utils/transaction';
-import { parseSorobanError } from '../utils/errors';
+import { addressToScVal, bigintToScVal } from '../utils/scval';
+import { buildContractCall, submitTransaction } from '../utils/transaction';
+import { parseSorobanError, VeriTixError, VeriTixErrorCode } from '../utils/errors';
 import { parseRecurringExecutionEntry } from '../utils/parsers';
 import { DUMMY_PUBLIC_KEY } from '../utils/network';
 
@@ -114,6 +114,48 @@ export class RecurringModule {
   async cancel(_id: bigint): Promise<TransactionResult> {
     // TODO: implement
     throw new Error('RecurringModule.cancel: not implemented');
+  }
+
+  /**
+   * Reassigns the payer of an existing recurring payment to a new address.
+   * Both the current and new payer must co-sign the transaction.
+   *
+   * @param id - Numeric recurring-payment identifier.
+   * @param newPayer - New payer Stellar account address.
+   * @returns A {@link TransactionResult} on success.
+   * @throws {Error} If no signing keypair is available.
+   */
+  async transferPayer(_id: bigint, _newPayer: string): Promise<TransactionResult> {
+    if (!this.keypair) {
+      throw new VeriTixError(VeriTixErrorCode.ReadOnlyClient, 'RecurringModule.transferPayer: signing keypair required');
+    }
+
+    const payer = this.keypair.publicKey();
+
+    const tx = await buildContractCall(
+      this.server,
+      new Account(payer, '0'),
+      this.config.contractId,
+      'transfer_payer',
+      [
+        bigintToScVal(_id, 'u64'),
+        addressToScVal(_newPayer),
+      ],
+      this.config.networkPassphrase,
+    );
+
+    const raw = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(raw)) {
+      throw parseSorobanError(raw.error);
+    }
+
+    const returnValue =
+      SorobanRpc.Api.isSimulationSuccess(raw) && raw.result ? raw.result.retval : undefined;
+
+    const assembled = SorobanRpc.assembleTransaction(tx, raw).build();
+    const result = await submitTransaction(this.server, assembled, this.keypair);
+
+    return { ...result, returnValue };
   }
 
   // -------------------------------------------------------------------------

--- a/tests/recurring.test.ts
+++ b/tests/recurring.test.ts
@@ -108,4 +108,31 @@ describe('RecurringModule', () => {
       expect(result.failed).toEqual([]);
     });
   });
+
+  describe('transferPayer()', () => {
+    it('throws ReadOnlyClient when no keypair', async () => {
+      await expect(recurring.transferPayer(1n, 'GNEW')).rejects.toThrow('signing keypair required');
+    });
+
+    it('returns tx result on success', async () => {
+      const kp = Keypair.random();
+      const c = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT), kp);
+      const mockServer = { simulateTransaction: jest.fn(), sendTransaction: jest.fn(), getTransaction: jest.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c as any).server = mockServer;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c as any).connected = true;
+
+      mockServer.simulateTransaction.mockResolvedValue({
+        status: 'SUCCESS',
+        result: { retval: undefined },
+      });
+      mockServer.sendTransaction.mockResolvedValue({ hash: 'transfer-hash', status: 'PENDING' });
+      mockServer.getTransaction.mockResolvedValue({ status: 'SUCCESS', successful: true, ledger: 55 });
+
+      const result = await c.recurring.transferPayer(3n, 'GNEWPAYER');
+      expect(result.successful).toBe(true);
+      expect(result.hash).toBe('transfer-hash');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implemented 	ransferPayer() - allows reassigning the payer of an existing recurring payment.

### Changes
- Added 	ransferPayer(id, newPayer) to RecurringModule - Requires signing keypair (current payer) - Calls contract transfer_payer method - Added 2 unit tests

Closes #244