### PR TITLE
Add SplitterModule.getRevenueSharePreview() to preview splits without mutation

### DIFF
--- a/src/modules/splitter.ts
+++ b/src/modules/splitter.ts
@@ -202,6 +202,35 @@ export class SplitterModule {
   }
 
   /**
+   * Returns a preview of how a revenue split would distribute funds to recipients,
+   * without performing any on-chain mutation. Useful for estimating payouts before
+   * committing to a split.
+   *
+   * @param params - Revenue split parameters (organizer, artist, platform, totalAmount).
+   * @returns Array of recipient addresses with their calculated share amounts.
+   *
+   * @example
+   * ```ts
+   * const preview = await client.splitter.getRevenueSharePreview({
+   *   organizer: 'GABC…', organizerBps: 4000,
+   *   artist: 'GXYZ…', artistBps: 3500,
+   *   platform: 'GDEF…', totalAmount: 10_000_000n,
+   * });
+   * preview.forEach(r => console.log(`${r.address}: ${r.amount}`));
+   * ```
+   */
+  getRevenueSharePreview(params: RevenueSplitParams): Array<{ address: string; amount: bigint }> {
+    const { organizer, organizerBps, artist, artistBps, platform, totalAmount } = params;
+    const platformBps = 10_000 - organizerBps - artistBps;
+
+    return [
+      { address: organizer, amount: (totalAmount * BigInt(organizerBps)) / 10_000n },
+      { address: artist, amount: (totalAmount * BigInt(artistBps)) / 10_000n },
+      { address: platform, amount: (totalAmount * BigInt(platformBps)) / 10_000n },
+    ];
+  }
+
+  /**
    * Distributes the split funds to all recipients on-chain.
    *
    * @param _id - Numeric split identifier.

--- a/tests/splitter.test.ts
+++ b/tests/splitter.test.ts
@@ -116,3 +116,34 @@ describe('SplitterModule.createRevenueSplit (validation)', () => {
     ).rejects.toMatchObject({ code: VeriTixErrorCode.SplitInvalidShares });
   });
 });
+
+describe('SplitterModule.getRevenueSharePreview', () => {
+  const client = new VeriTixClient(getTestnetConfig(FAKE_CONTRACT), Keypair.random());
+
+  it('calculates correct shares for a three-way split', () => {
+    const preview = client.splitter.getRevenueSharePreview({
+      organizer: 'GORG...',
+      organizerBps: 4000,
+      artist: 'GART...',
+      artistBps: 3500,
+      platform: 'GPLAT...',
+      totalAmount: 10_000_000n,
+    });
+    expect(preview).toHaveLength(3);
+    expect(preview[0]).toEqual({ address: 'GORG...', amount: 4_000_000n });
+    expect(preview[1]).toEqual({ address: 'GART...', amount: 3_500_000n });
+    expect(preview[2]).toEqual({ address: 'GPLAT...', amount: 2_500_000n });
+  });
+
+  it('handles zero-amount split', () => {
+    const preview = client.splitter.getRevenueSharePreview({
+      organizer: 'GORG...',
+      organizerBps: 5000,
+      artist: 'GART...',
+      artistBps: 5000,
+      platform: 'GPLAT...',
+      totalAmount: 0n,
+    });
+    expect(preview.every(r => r.amount === 0n)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implemented getRevenueSharePreview() - a pure read-only function that previews how a revenue split distributes funds to recipients.

### Changes
- Added getRevenueSharePreview(params) to SplitterModule - Pure calculation, no on-chain call - Returns array of {address, amount} for each recipient - Added 2 unit tests

Closes #246