### PR TITLE
security(utils): add memo length validation to prevent contract panics

### DIFF
--- a/docs/security-memo-validation.md
+++ b/docs/security-memo-validation.md
@@ -1,0 +1,14 @@
+# Security Memo Validation Guide
+
+This document explains the input sanitization enforced by `MemoValidationService` to prevent smart contract panics caused by malformed or oversized memo strings on Stellar.
+
+## Architecture
+
+1. **Memo Validation Service**:
+   - `src/utils/validation/memo.service.ts`: Exposes `validate()` to check byte length against the 28-byte Stellar limit.
+
+2. **Validation Schemas**:
+   - `memoValidationResultSchema` ensures the output structure is consistent.
+
+3. **Testing**:
+   - Covered in `tests/utils/validation/memo.service.spec.ts`.

--- a/src/utils/validation/memo.schemas.ts
+++ b/src/utils/validation/memo.schemas.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+// Stellar memos max length is 28 bytes
+export const MAX_MEMO_LENGTH = 28;
+
+export const memoValidationOptionsSchema = z.object({
+  memo: z.string(),
+  enforceMaxLength: z.boolean().default(true),
+});
+
+export const memoValidationResultSchema = z.object({
+  isValid: z.boolean(),
+  sanitizedMemo: z.string(),
+  error: z.string().optional(),
+});

--- a/src/utils/validation/memo.service.ts
+++ b/src/utils/validation/memo.service.ts
@@ -1,0 +1,25 @@
+import { MAX_MEMO_LENGTH, memoValidationResultSchema } from './memo.schemas';
+import type { MemoValidationOptions, MemoValidationResult } from './memo.types';
+
+export class MemoValidationService {
+  /**
+   * Validates and sanitizes a memo string to prevent contract panic on oversize.
+   */
+  public validate(options: MemoValidationOptions): MemoValidationResult {
+    const { memo, enforceMaxLength } = options;
+    const byteLength = Buffer.byteLength(memo, 'utf8');
+
+    if (enforceMaxLength && byteLength > MAX_MEMO_LENGTH) {
+      return memoValidationResultSchema.parse({
+        isValid: false,
+        sanitizedMemo: memo.substring(0, MAX_MEMO_LENGTH),
+        error: `Memo exceeds max length of ${MAX_MEMO_LENGTH} bytes.`,
+      });
+    }
+
+    return memoValidationResultSchema.parse({
+      isValid: true,
+      sanitizedMemo: memo,
+    });
+  }
+}

--- a/src/utils/validation/memo.types.ts
+++ b/src/utils/validation/memo.types.ts
@@ -1,0 +1,10 @@
+export interface MemoValidationOptions {
+  memo: string;
+  enforceMaxLength: boolean;
+}
+
+export interface MemoValidationResult {
+  isValid: boolean;
+  sanitizedMemo: string;
+  error?: string;
+}

--- a/tests/utils/validation/memo.service.spec.ts
+++ b/tests/utils/validation/memo.service.spec.ts
@@ -1,0 +1,24 @@
+import { MemoValidationService } from '../../../src/utils/validation/memo.service';
+
+describe('MemoValidationService', () => {
+  let service: MemoValidationService;
+
+  beforeEach(() => {
+    service = new MemoValidationService();
+  });
+
+  it('should validate short memos successfully', () => {
+    const result = service.validate({ memo: 'Invoice #123', enforceMaxLength: true });
+    expect(result.isValid).toBe(true);
+    expect(result.sanitizedMemo).toBe('Invoice #123');
+  });
+
+  it('should invalidate memos exceeding 28 bytes', () => {
+    const longMemo = 'This memo is way too long and will definitely exceed twenty eight bytes';
+    const result = service.validate({ memo: longMemo, enforceMaxLength: true });
+    
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('exceeds max length');
+    expect(result.sanitizedMemo.length).toBe(28);
+  });
+});


### PR DESCRIPTION
Implemented `MemoValidationService` to ensure memo strings do not exceed the 28-byte Stellar limit before submission.

Highlights:
- Created MemoValidationService in src/utils/validation
- Added memoValidationResultSchema in src/utils/validation
- Added unit tests in tests/utils/validation
- Documented feature in docs/security-memo-validation.md

close #320
close #319
close #318
close #317