### PR TITLE
fix(splitter): add BPS validation to prevent negative platform share

### DIFF
--- a/docs/fix-splitter-bps.md
+++ b/docs/fix-splitter-bps.md
@@ -1,0 +1,14 @@
+# Splitter BPS Validation Guide
+
+This document explains the input validation logic added to `SplitterModule.createRevenueSplit` to prevent the platform from receiving a negative revenue share on Stellar.
+
+## Architecture
+
+1. **Splitter Service**:
+   - `src/modules/splitter/splitter.service.ts`: Exposes `createRevenueSplit()` and enforces that `organizerBps + artistBps <= 10000`.
+
+2. **Validation Schemas**:
+   - `splitConfigSchema` ensures the input types are integers between 0 and 10000.
+
+3. **Testing**:
+   - Covered in `tests/modules/splitter/splitter.service.spec.ts`.

--- a/src/modules/splitter/splitter.schemas.ts
+++ b/src/modules/splitter/splitter.schemas.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const splitConfigSchema = z.object({
+  organizerBps: z.number().int().min(0).max(10000),
+  artistBps: z.number().int().min(0).max(10000),
+});
+
+export const bpsValidationResultSchema = z.object({
+  isValid: z.boolean(),
+  platformBps: z.number().int(),
+  error: z.string().optional(),
+});

--- a/src/modules/splitter/splitter.service.ts
+++ b/src/modules/splitter/splitter.service.ts
@@ -1,0 +1,29 @@
+import { splitConfigSchema, bpsValidationResultSchema } from './splitter.schemas';
+import type { SplitConfig, BpsValidationResult } from './splitter.types';
+
+export class SplitterModule {
+  /**
+   * Validates a split configuration ensuring the total allocated BPS does not exceed 10000.
+   */
+  public createRevenueSplit(config: SplitConfig): BpsValidationResult {
+    splitConfigSchema.parse(config);
+    
+    const { organizerBps, artistBps } = config;
+    const totalAllocated = organizerBps + artistBps;
+
+    if (totalAllocated > 10000) {
+      return bpsValidationResultSchema.parse({
+        isValid: false,
+        platformBps: 0,
+        error: `Total allocated BPS (${totalAllocated}) exceeds 10000. Platform share would be negative.`,
+      });
+    }
+
+    const platformBps = 10000 - totalAllocated;
+
+    return bpsValidationResultSchema.parse({
+      isValid: true,
+      platformBps,
+    });
+  }
+}

--- a/src/modules/splitter/splitter.types.ts
+++ b/src/modules/splitter/splitter.types.ts
@@ -1,0 +1,10 @@
+export interface SplitConfig {
+  organizerBps: number;
+  artistBps: number;
+}
+
+export interface BpsValidationResult {
+  isValid: boolean;
+  platformBps: number;
+  error?: string;
+}

--- a/tests/modules/splitter/splitter.service.spec.ts
+++ b/tests/modules/splitter/splitter.service.spec.ts
@@ -1,0 +1,22 @@
+import { SplitterModule } from '../../../src/modules/splitter/splitter.service';
+
+describe('SplitterModule', () => {
+  let module: SplitterModule;
+
+  beforeEach(() => {
+    module = new SplitterModule();
+  });
+
+  it('should validate a correct split configuration and calculate platform share', () => {
+    const result = module.createRevenueSplit({ organizerBps: 8000, artistBps: 1000 });
+    expect(result.isValid).toBe(true);
+    expect(result.platformBps).toBe(1000); // 10000 - 9000
+  });
+
+  it('should reject a split configuration that exceeds 10000 BPS in total', () => {
+    const result = module.createRevenueSplit({ organizerBps: 6000, artistBps: 5000 });
+    expect(result.isValid).toBe(false);
+    expect(result.platformBps).toBe(0);
+    expect(result.error).toContain('exceeds 10000');
+  });
+});


### PR DESCRIPTION
Implemented `SplitterModule.createRevenueSplit` validation to ensure organizer and artist BPS do not exceed 10000.

Highlights:
- Created SplitterModule validation in src/modules/splitter
- Added splitConfigSchema in src/modules/splitter
- Added unit tests in tests/modules/splitter
- Documented feature in docs/fix-splitter-bps.md

close #316
close #315
close #314
close #313